### PR TITLE
Add settings reset option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,7 @@ You will need to point it to your `/build` folder location as mentioned above
   - `public/manifest.json`
 
 And the new version should appear within the app when you open it
+
+##### Resetting settings
+
+Use the options menu to select **Reset All Settings** if you want to clear all stored headers and filters.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -237,6 +237,7 @@ function App() {
               removePage={removePage}
               changePageIndex={changePageIndex}
               toggleDarkMode={toggleDarkMode}
+              clearSettings={clear}
             />
             <div key={selectedPage} className="app__body__contents">
               <div>

--- a/src/components/pageOptionsDropdown/index.tsx
+++ b/src/components/pageOptionsDropdown/index.tsx
@@ -9,12 +9,14 @@ const PageOptionsDropdown = ({
   removePage,
   updatePageName,
   toggleDarkMode,
+  clearSettings,
 }: {
   page: Page;
   darkModeEnabled: boolean;
   removePage: () => void;
   updatePageName: (name: string, id: number) => void;
   toggleDarkMode: () => void;
+  clearSettings: () => void;
 }) => {
   const [show, setShow] = useState(false);
   const optionButtonRef = useRef<HTMLDivElement>(null);
@@ -102,6 +104,16 @@ const PageOptionsDropdown = ({
         </div>
         <div className="page-options-dropdown__item">
           <Button onClick={_removePage} width="full" content="Delete Page" />
+        </div>
+        <div className="page-options-dropdown__item">
+          <Button
+            onClick={() => {
+              clearSettings();
+              setShow(false);
+            }}
+            width="full"
+            content="Reset All Settings"
+          />
         </div>
       </div>
     </>

--- a/src/components/pagesTabs/index.tsx
+++ b/src/components/pagesTabs/index.tsx
@@ -12,6 +12,7 @@ const PagesTabs = ({
   updatePageKeepEnabled,
   changePageIndex,
   toggleDarkMode,
+  clearSettings,
 }: {
   currentPage: Page;
   darkModeEnabled: boolean;
@@ -21,6 +22,7 @@ const PagesTabs = ({
   updatePageKeepEnabled: (id: number, enabled: boolean) => void;
   changePageIndex: (id: number, newIndex: number) => void;
   toggleDarkMode: () => void;
+  clearSettings: () => void;
 }) => {
   return (
     <div className="pages-tabs__actions">
@@ -55,6 +57,7 @@ const PagesTabs = ({
             updatePageName(name, currentPage.id)
           }
           toggleDarkMode={toggleDarkMode}
+          clearSettings={clearSettings}
         />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add `clearSettings` action in `PagesTabs` and `PageOptionsDropdown`
- invoke `clear` from the main app when reset option is selected
- document reset ability in README

## Testing
- `npm test` *(fails: react-app-rewired not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840372908c48321b3749648697a45b4