### PR TITLE
Add request/response selection for headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flex-headers",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "private": true,
   "dependencies": {
     "@craco/craco": "^7.1.0",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "FlexHeaders - Edit HTTP Headers",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "manifest_version": 3,
   "description": "Modify request headers, filter by URL, share headers with friends, and import/export settings.",
   "icons": {

--- a/src/App.css
+++ b/src/App.css
@@ -3,7 +3,7 @@
   background-color: var(--background-primary);
   color: var(--text-color);
 
-  width: 680px;
+  width: 760px;
   height: 600px;
   max-height: 600px;
   overflow: hidden;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -79,6 +79,7 @@ function App() {
       headerName: "",
       headerValue: "",
       headerEnabled: true,
+      headerType: "request",
     });
 
     setHeaderToFocus(newHeader?.id ?? null);
@@ -265,7 +266,7 @@ function App() {
                       >
                         {currentPage?.headers?.map(
                           (
-                            { id, headerName, headerValue, headerEnabled },
+                            { id, headerName, headerValue, headerEnabled, headerType },
                             index
                           ) => (
                             <Draggable key={id} draggableId={id} index={index}>
@@ -280,18 +281,21 @@ function App() {
                                     headerName={headerName}
                                     headerValue={headerValue}
                                     headerEnabled={headerEnabled}
+                                    headerType={headerType}
                                     onRemove={(id: string) => _removeHeader(id)}
                                     onUpdate={(
                                       id: string,
                                       name: string,
                                       value: string,
-                                      enabled: boolean
+                                      enabled: boolean,
+                                      type: "request" | "response"
                                     ) =>
                                       _updateHeader({
                                         id: id,
                                         headerName: name,
                                         headerValue: value,
                                         headerEnabled: enabled,
+                                        headerType: type,
                                       })
                                     }
                                     dragHandleProps={provided.dragHandleProps}

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -30,7 +30,7 @@ export function getAndApplyHeaderRules() {
           (page: Page) => {
             if (page.enabled || page.keepEnabled) {
               // each setting
-              page.headers.forEach((header) => {
+              page.headers.forEach((header: any) => {
                 if (header.headerEnabled && header.headerName) {
                   // Check for filters
                   let regexFilter = "";
@@ -56,18 +56,31 @@ export function getAndApplyHeaderRules() {
                   }
 
                   // Ready to push
+                  const hType = header.headerType || "request";
                   headers.push({
                     id: getUniqueRuleID(),
                     priority: 1,
                     action: {
                       type: "modifyHeaders",
-                      requestHeaders: [
-                        {
-                          header: header.headerName,
-                          operation: "set",
-                          value: header.headerValue,
-                        },
-                      ],
+                      ...(hType === "request"
+                        ? {
+                            requestHeaders: [
+                              {
+                                header: header.headerName,
+                                operation: "set",
+                                value: header.headerValue,
+                              },
+                            ],
+                          }
+                        : {
+                            responseHeaders: [
+                              {
+                                header: header.headerName,
+                                operation: "set",
+                                value: header.headerValue,
+                              },
+                            ],
+                          }),
                     },
                     condition: {
                       regexFilter: regexFilter || "|http*",

--- a/src/components/headerRow/index.css
+++ b/src/components/headerRow/index.css
@@ -9,7 +9,8 @@
 }
 
 .header-row__name,
-.header-row__value {
+.header-row__value,
+.header-row__type {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;

--- a/src/components/headerRow/index.tsx
+++ b/src/components/headerRow/index.tsx
@@ -8,24 +8,35 @@ const HeaderRow = ({
   headerName,
   headerValue,
   headerEnabled,
+  headerType,
   onRemove,
   onUpdate,
   dragHandleProps,
 }: HeaderSetting & {
   onRemove: (id: string) => void;
-  onUpdate: (id: string, name: string, value: string, enabled: boolean) => void;
+  onUpdate: (
+    id: string,
+    name: string,
+    value: string,
+    enabled: boolean,
+    type: "request" | "response"
+  ) => void;
   dragHandleProps?: DraggableProvidedDragHandleProps | null | undefined;
 }) => {
   const updateName = (e: React.ChangeEvent<HTMLInputElement>) => {
-    onUpdate(id, e.target.value, headerValue, headerEnabled);
+    onUpdate(id, e.target.value, headerValue, headerEnabled, headerType);
   };
 
   const updateValue = (e: React.ChangeEvent<HTMLInputElement>) => {
-    onUpdate(id, headerName, e.target.value, headerEnabled);
+    onUpdate(id, headerName, e.target.value, headerEnabled, headerType);
   };
 
   const updateEnabled = (e: React.ChangeEvent<HTMLInputElement>) => {
-    onUpdate(id, headerName, headerValue, e.target.checked);
+    onUpdate(id, headerName, headerValue, e.target.checked, headerType);
+  };
+
+  const updateType = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    onUpdate(id, headerName, headerValue, headerEnabled, e.target.value as "request" | "response");
   };
 
   const handleFocus = (e: React.FocusEvent<HTMLInputElement>) => {
@@ -66,6 +77,12 @@ const HeaderRow = ({
           onChange={updateValue}
           onFocus={handleFocus}
         />
+      </div>
+      <div className="header-row__type">
+        <select value={headerType} onChange={updateType}>
+          <option value="request">Request</option>
+          <option value="response">Response</option>
+        </select>
       </div>
       <div className="header-row__remove" onClick={() => onRemove(id)}>
         <Button

--- a/src/components/headerRow/index.tsx
+++ b/src/components/headerRow/index.tsx
@@ -79,7 +79,7 @@ const HeaderRow = ({
         />
       </div>
       <div className="header-row__type">
-        <select value={headerType} onChange={updateType}>
+        <select value={headerType} onChange={updateType} aria-label="Header type">
           <option value="request">Request</option>
           <option value="response">Response</option>
         </select>

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -135,7 +135,7 @@ function useFlexHeaderSettings() {
             })
             .map((p: any) => ({
               ...p,
-              headers: p.headers.map((h: any) => ({
+              headers: p.headers.map((h: HeaderSetting) => ({
                 ...h,
                 headerType: h.headerType ? h.headerType : "request",
               })),

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -27,6 +27,7 @@ export type HeaderSetting = {
   headerName: string;
   headerValue: string;
   headerEnabled: boolean;
+  headerType: "request" | "response";
 };
 
 export type PagesData = {
@@ -46,6 +47,7 @@ const defaultPage: Page = {
       headerName: "X-Frame-Options",
       headerValue: "ALLOW-FROM https://www.youtube.com/",
       headerEnabled: true,
+      headerType: "request",
     },
   ],
 };
@@ -127,9 +129,17 @@ function useFlexHeaderSettings() {
             return;
           }
 
-          oldSettings.pages = data.settings.sort((a: Page, b: Page) => {
-            return a.id - b.id;
-          });
+          oldSettings.pages = data.settings
+            .sort((a: Page, b: Page) => {
+              return a.id - b.id;
+            })
+            .map((p: any) => ({
+              ...p,
+              headers: p.headers.map((h: any) => ({
+                ...h,
+                headerType: h.headerType ? h.headerType : "request",
+              })),
+            }));
 
           browser.storage.sync.get(SELECTED_PAGE_KEY).then((data) => {
             if (data[SELECTED_PAGE_KEY] === undefined) {
@@ -150,7 +160,15 @@ function useFlexHeaderSettings() {
           });
         });
       } else {
-        setPagesData(data[SETTINGS_KEY] as PagesData);
+        const loaded = data[SETTINGS_KEY] as PagesData;
+        const mappedPages = loaded.pages.map((p) => ({
+          ...p,
+          headers: p.headers.map((h: any) => ({
+            ...h,
+            headerType: h.headerType ? h.headerType : "request",
+          })),
+        }));
+        setPagesData({ ...loaded, pages: mappedPages });
         setHasInitialized(true);
       }
     });
@@ -327,6 +345,7 @@ function useFlexHeaderSettings() {
               ...page.headers,
               {
                 ...header,
+                headerType: header.headerType || "request",
                 id: `${pageId}-${page.headers.length + 1}`,
               },
             ],
@@ -506,10 +525,14 @@ function useFlexHeaderSettings() {
         if (Array.isArray(parsed)) {
           // remap the ids to avoid conflicts
           const combinedPages = [...pagesData.pages, ...parsed];
-          const newPages = combinedPages.map((page, index) => {
+          const newPages = combinedPages.map((page: any, index) => {
             return {
               ...page,
               id: index,
+              headers: page.headers.map((h: any) => ({
+                ...h,
+                headerType: h.headerType ? h.headerType : "request",
+              })),
             };
           });
 


### PR DESCRIPTION
## Summary
- widen the options page width
- allow choosing whether a header modifies request or response
- persist new setting on import/export and background rules

## Testing
- `npm test --silent` *(fails: react-app-rewired not found)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686ab81254108321b279913e114192ad