### PR TITLE
Add comments to header settings

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -133,6 +133,7 @@ function App() {
         id: newId,
         enabled: true,
         keepEnabled: false,
+        showHeaderComments: true,
         name: "New Page",
         headers: [],
         filters: [],
@@ -174,6 +175,18 @@ function App() {
 
       if (page) {
         page.keepEnabled = enabled;
+        updatePage(page);
+      }
+    },
+    [pages, updatePage]
+  );
+
+  const _changePageShowHeaderComments = useCallback(
+    async (id: number, showHeaderComments: boolean) => {
+      const page = pages.find((x) => x.id === id);
+
+      if (page) {
+        page.showHeaderComments = showHeaderComments;
         updatePage(page);
       }
     },
@@ -265,6 +278,7 @@ function App() {
               addPage={_addPage}
               updatePageName={_updatePageName}
               updatePageKeepEnabled={_changePageKeepEnabled}
+              updatePageShowHeaderComments={_changePageShowHeaderComments}
               removePage={removePage}
               changePageIndex={changePageIndex}
               toggleDarkMode={toggleDarkMode}
@@ -304,6 +318,7 @@ function App() {
                                     headerComment={headerComment}
                                     headerEnabled={headerEnabled}
                                     headerType={headerType}
+                                    showComment={currentPage.showHeaderComments}
                                     onRemove={(id: string) => _removeHeader(id)}
                                     onUpdate={_updateHeader}
                                     dragHandleProps={provided.dragHandleProps}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -80,6 +80,7 @@ function App() {
     const newHeader = addHeader(currentPage.id, {
       headerName: "",
       headerValue: "",
+      headerComment: "",
       headerEnabled: true,
       headerType: "request",
     });
@@ -286,7 +287,7 @@ function App() {
                       >
                         {currentPage?.headers?.map(
                           (
-                            { id, headerName, headerValue, headerEnabled, headerType },
+                            { id, headerName, headerValue, headerComment, headerEnabled, headerType },
                             index
                           ) => (
                             <Draggable key={id} draggableId={id} index={index}>
@@ -300,24 +301,11 @@ function App() {
                                     id={id}
                                     headerName={headerName}
                                     headerValue={headerValue}
+                                    headerComment={headerComment}
                                     headerEnabled={headerEnabled}
                                     headerType={headerType}
                                     onRemove={(id: string) => _removeHeader(id)}
-                                    onUpdate={(
-                                      id: string,
-                                      name: string,
-                                      value: string,
-                                      enabled: boolean,
-                                      type: "request" | "response"
-                                    ) =>
-                                      _updateHeader({
-                                        id: id,
-                                        headerName: name,
-                                        headerValue: value,
-                                        headerEnabled: enabled,
-                                        headerType: type,
-                                      })
-                                    }
+                                    onUpdate={_updateHeader}
                                     dragHandleProps={provided.dragHandleProps}
                                   />
                                 </div>

--- a/src/components/dragDropFile/index.tsx
+++ b/src/components/dragDropFile/index.tsx
@@ -2,7 +2,7 @@ import { useRef } from "react";
 import "./index.css";
 
 interface DragDropFileProps {
-  importSettings: (file: File) => void;
+  importSettings: (file: File) => Promise<void>;
   closeCallback: () => void;
 }
 
@@ -10,16 +10,17 @@ const DragDropFile = ({ importSettings, closeCallback }: DragDropFileProps) => {
   const inputRef = useRef<HTMLInputElement>(null);
 
   // triggers when file is selected with click
-  const handleChange = function (e: React.ChangeEvent<HTMLInputElement>) {
+  const handleChange = async function (e: React.ChangeEvent<HTMLInputElement>) {
     e.preventDefault();
     if (e.target.files && e.target.files[0]) {
-      importSettings(e.target.files[0]);
+      await importSettings(e.target.files[0]);
       closeCallback();
     }
   };
 
   // triggers the input when the button is clicked
-  const onButtonClick = () => {
+  const onButtonClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
     if (inputRef.current && inputRef.current.click) {
       inputRef.current.click();
     }
@@ -34,9 +35,9 @@ const DragDropFile = ({ importSettings, closeCallback }: DragDropFileProps) => {
         accept=".json"
         onChange={handleChange}
       />
-      <label id="label-file-upload" htmlFor="input-file-upload">
+      <label id="label-file-upload">
         <div>
-          <button className="upload-button" onClick={onButtonClick}>
+          <button type="button" className="upload-button" onClick={onButtonClick}>
             Click to upload a file
           </button>
         </div>

--- a/src/components/headerRow/index.css
+++ b/src/components/headerRow/index.css
@@ -9,7 +9,8 @@
 }
 
 .header-row__name,
-.header-row__value {
+.header-row__value,
+.header-row__comment {
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
@@ -20,10 +21,20 @@
 
 /* Optimize input fields for better space usage */
 .header-row__name input,
-.header-row__value input {
+.header-row__value input,
+.header-row__comment input {
   padding: 5px 8px;
   height: 28px;
   box-sizing: border-box;
+}
+
+.header-row__name,
+.header-row__value {
+  flex: 1.1;
+}
+
+.header-row__comment {
+  flex: 0.9;
 }
 
 .header-row__type {

--- a/src/components/headerRow/index.css
+++ b/src/components/headerRow/index.css
@@ -37,6 +37,11 @@
   flex: 0.9;
 }
 
+.header-row--comments-hidden .header-row__name,
+.header-row--comments-hidden .header-row__value {
+  flex: 1;
+}
+
 .header-row__type {
   display: flex;
   flex-direction: column;

--- a/src/components/headerRow/index.tsx
+++ b/src/components/headerRow/index.tsx
@@ -13,7 +13,9 @@ const HeaderRow = ({
   onRemove,
   onUpdate,
   dragHandleProps,
+  showComment,
 }: HeaderSetting & {
+  showComment: boolean;
   onRemove: (id: string) => void;
   onUpdate: (header: HeaderSetting) => void;
   dragHandleProps?: DraggableProvidedDragHandleProps | null | undefined;
@@ -55,7 +57,7 @@ const HeaderRow = ({
   };
 
   return (
-    <div className="header-row" data-headerId={id}>
+    <div className={`header-row${showComment ? "" : " header-row--comments-hidden"}`} data-headerId={id}>
       <div className="header-row__checkbox">
         {dragHandleProps && (
           <img
@@ -89,15 +91,17 @@ const HeaderRow = ({
           onFocus={handleFocus}
         />
       </div>
-      <div className="header-row__comment">
-        <input
-          type="text"
-          placeholder="Comment"
-          value={headerComment}
-          onChange={updateComment}
-          onFocus={handleFocus}
-        />
-      </div>
+      {showComment && (
+        <div className="header-row__comment">
+          <input
+            type="text"
+            placeholder="Comment"
+            value={headerComment}
+            onChange={updateComment}
+            onFocus={handleFocus}
+          />
+        </div>
+      )}
       <div className="header-row__type">
         <select
           value={headerType}

--- a/src/components/headerRow/index.tsx
+++ b/src/components/headerRow/index.tsx
@@ -7,6 +7,7 @@ const HeaderRow = ({
   id,
   headerName,
   headerValue,
+  headerComment,
   headerEnabled,
   headerType,
   onRemove,
@@ -14,29 +15,39 @@ const HeaderRow = ({
   dragHandleProps,
 }: HeaderSetting & {
   onRemove: (id: string) => void;
-  onUpdate: (
-    id: string,
-    name: string,
-    value: string,
-    enabled: boolean,
-    type: "request" | "response"
-  ) => void;
+  onUpdate: (header: HeaderSetting) => void;
   dragHandleProps?: DraggableProvidedDragHandleProps | null | undefined;
 }) => {
+  const updateHeader = (patch: Partial<HeaderSetting>) => {
+    onUpdate({
+      id,
+      headerName,
+      headerValue,
+      headerComment,
+      headerEnabled,
+      headerType,
+      ...patch,
+    });
+  };
+
   const updateName = (e: React.ChangeEvent<HTMLInputElement>) => {
-    onUpdate(id, e.target.value, headerValue, headerEnabled, headerType);
+    updateHeader({ headerName: e.target.value });
   };
 
   const updateValue = (e: React.ChangeEvent<HTMLInputElement>) => {
-    onUpdate(id, headerName, e.target.value, headerEnabled, headerType);
+    updateHeader({ headerValue: e.target.value });
+  };
+
+  const updateComment = (e: React.ChangeEvent<HTMLInputElement>) => {
+    updateHeader({ headerComment: e.target.value });
   };
 
   const updateEnabled = (e: React.ChangeEvent<HTMLInputElement>) => {
-    onUpdate(id, headerName, headerValue, e.target.checked, headerType);
+    updateHeader({ headerEnabled: e.target.checked });
   };
 
   const updateType = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    onUpdate(id, headerName, headerValue, headerEnabled, e.target.value as "request" | "response");
+    updateHeader({ headerType: e.target.value as "request" | "response" });
   };
 
   const handleFocus = (e: React.FocusEvent<HTMLInputElement>) => {
@@ -75,6 +86,15 @@ const HeaderRow = ({
           placeholder="Value"
           value={headerValue}
           onChange={updateValue}
+          onFocus={handleFocus}
+        />
+      </div>
+      <div className="header-row__comment">
+        <input
+          type="text"
+          placeholder="Comment"
+          value={headerComment}
+          onChange={updateComment}
           onFocus={handleFocus}
         />
       </div>

--- a/src/components/importPopup/index.tsx
+++ b/src/components/importPopup/index.tsx
@@ -5,7 +5,7 @@ import Divider from "../divider";
 import DragDropFile from "../dragDropFile";
 
 interface ImportPopupProps {
-  importSettings: (file: File) => void;
+  importSettings: (file: File) => Promise<void>;
 }
 
 const ImportPopup = ({ importSettings }: ImportPopupProps) => {
@@ -15,8 +15,6 @@ const ImportPopup = ({ importSettings }: ImportPopupProps) => {
   const _handleClick = () => {
     setShow(!show);
   };
-
-  const _handleExport = () => { };
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -67,22 +65,6 @@ const ImportPopup = ({ importSettings }: ImportPopupProps) => {
         <Divider thin />
         <div className="import-popup__actions">
           <Button content="Cancel" onClick={() => setShow(false)} />
-          <Button
-            content={
-              <div
-                style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}
-              >
-                <img
-                  src="/icons/import.svg"
-                  alt="import Pages"
-                  width={16}
-                  height={16}
-                />
-                <span>Import</span>
-              </div>
-            }
-            onClick={_handleExport}
-          />
         </div>
       </div>
     </>

--- a/src/components/pagesTabs/index.css
+++ b/src/components/pagesTabs/index.css
@@ -15,6 +15,10 @@
   gap: 0.5rem;
   align-items: center;
 }
+
+.pages-tabs__actions__buttons label {
+  white-space: nowrap;
+}
 .page-tabs__show-all {
   width: 2rem;
   cursor: pointer;

--- a/src/components/pagesTabs/index.tsx
+++ b/src/components/pagesTabs/index.tsx
@@ -11,6 +11,7 @@ const PagesTabs = ({
   removePage,
   updatePageName,
   updatePageKeepEnabled,
+  updatePageShowHeaderComments,
   changePageIndex,
   toggleDarkMode,
   toggleSync,
@@ -22,6 +23,7 @@ const PagesTabs = ({
   removePage: (id: number, autoSelectPage: boolean) => void;
   updatePageName: (name: string, id: number) => void;
   updatePageKeepEnabled: (id: number, enabled: boolean) => void;
+  updatePageShowHeaderComments: (id: number, showHeaderComments: boolean) => void;
   changePageIndex: (id: number, newIndex: number) => void;
   toggleDarkMode: () => void;
   toggleSync: () => void;
@@ -37,6 +39,14 @@ const PagesTabs = ({
           }
         />
         <label>Enabled in background</label>
+        <input
+          type="checkbox"
+          checked={currentPage.showHeaderComments}
+          onChange={(e) =>
+            updatePageShowHeaderComments(currentPage.id, e.target.checked)
+          }
+        />
+        <label>Show header comments</label>
       </div>
       <div className="pages-tabs__actions__buttons">
         <Button

--- a/src/utils/headers.ts
+++ b/src/utils/headers.ts
@@ -8,5 +8,6 @@ export const normalizeHeader = (header: any): HeaderSetting => ({
 
 export const normalizePage = (page: any): Page => ({
   ...page,
+  showHeaderComments: page.showHeaderComments ?? true,
   headers: page.headers?.map(normalizeHeader) || [],
 });

--- a/src/utils/headers.ts
+++ b/src/utils/headers.ts
@@ -1,0 +1,12 @@
+import type { HeaderSetting, Page } from "./settings";
+
+export const normalizeHeader = (header: any): HeaderSetting => ({
+  ...header,
+  headerComment: header.headerComment ?? "",
+  headerType: header.headerType || "request",
+});
+
+export const normalizePage = (page: any): Page => ({
+  ...page,
+  headers: page.headers?.map(normalizeHeader) || [],
+});

--- a/src/utils/settings.test.ts
+++ b/src/utils/settings.test.ts
@@ -101,6 +101,7 @@ const createPage = (
   name,
   enabled,
   keepEnabled: false,
+  showHeaderComments: true,
   headers,
   filters,
 });
@@ -489,5 +490,37 @@ describe('Header Comment Import/Export', () => {
       headerComment: '',
       headerType: 'request',
     });
+  });
+
+  it('should preserve the header comments visibility setting through JSON import/export', () => {
+    const pages = [
+      {
+        ...createPage(0, 'Routes', true, [createHeader('X-Route', 'service-a')]),
+        showHeaderComments: false,
+      },
+    ];
+
+    const exportedJson = JSON.stringify(pages);
+    const importedPages = (JSON.parse(exportedJson) as Page[]).map(normalizePage);
+
+    expect(importedPages[0].showHeaderComments).toBe(false);
+  });
+
+  it('should show header comments by default for legacy imported pages', () => {
+    const legacyPages = [
+      {
+        id: 0,
+        name: 'Legacy Routes',
+        enabled: true,
+        keepEnabled: false,
+        filters: [],
+        headers: [createHeader('X-Route', 'legacy-service')],
+      },
+    ];
+
+    const exportedJson = JSON.stringify(legacyPages);
+    const importedPages = (JSON.parse(exportedJson) as Page[]).map(normalizePage);
+
+    expect(importedPages[0].showHeaderComments).toBe(true);
   });
 });

--- a/src/utils/settings.test.ts
+++ b/src/utils/settings.test.ts
@@ -9,6 +9,7 @@
  */
 
 import { Page, HeaderSetting, HeaderFilter } from './settings';
+import { normalizePage } from './headers';
 
 // Extract the merge logic functions for testing
 // These are pure functions that can be tested independently
@@ -76,6 +77,7 @@ const createHeader = (name: string, value: string, enabled = true): HeaderSettin
   id: `test-${Date.now()}-${Math.random()}`,
   headerName: name,
   headerValue: value,
+  headerComment: '',
   headerEnabled: enabled,
   headerType: 'request',
 });
@@ -352,6 +354,7 @@ describe('New User Scenarios', () => {
         id: 'default-1',
         headerName: 'X-Frame-Options',
         headerValue: 'ALLOW-FROM https://www.youtube.com/',
+        headerComment: '',
         headerEnabled: true,
         headerType: 'request',
       },
@@ -370,6 +373,7 @@ describe('New User Scenarios', () => {
         id: 'default-1',
         headerName: 'X-Frame-Options',
         headerValue: 'ALLOW-FROM https://www.youtube.com/',
+        headerComment: '',
         headerEnabled: true,
         headerType: 'request',
       },
@@ -435,6 +439,55 @@ describe('Existing User Scenarios', () => {
       expect(result.map(p => p.name)).toContain('Shared Page');
       expect(result.map(p => p.name)).toContain('Browser A Only');
       expect(result.map(p => p.name)).toContain('Browser B Only');
+    });
+  });
+});
+
+describe('Header Comment Import/Export', () => {
+  it('should preserve header comments through exported JSON and imported pages', () => {
+    const pages = [
+      createPage(0, 'Routes', true, [
+        {
+          ...createHeader('X-Route', 'service-a'),
+          headerComment: 'Use for checkout API',
+        },
+        {
+          ...createHeader('X-Route', 'service-b'),
+          headerComment: 'Use for catalog API',
+        },
+      ]),
+    ];
+
+    const exportedJson = JSON.stringify(pages);
+    const importedPages = (JSON.parse(exportedJson) as Page[]).map(normalizePage);
+
+    expect(importedPages[0].headers[0].headerComment).toBe('Use for checkout API');
+    expect(importedPages[0].headers[1].headerComment).toBe('Use for catalog API');
+  });
+
+  it('should add an empty header comment when importing legacy headers', () => {
+    const legacyPages = [
+      {
+        ...createPage(0, 'Legacy Routes', true, []),
+        headers: [
+          {
+            id: 'legacy-1',
+            headerName: 'X-Route',
+            headerValue: 'legacy-service',
+            headerEnabled: true,
+          },
+        ],
+      },
+    ];
+
+    const exportedJson = JSON.stringify(legacyPages);
+    const importedPages = (JSON.parse(exportedJson) as Page[]).map(normalizePage);
+
+    expect(importedPages[0].headers[0]).toMatchObject({
+      headerName: 'X-Route',
+      headerValue: 'legacy-service',
+      headerComment: '',
+      headerType: 'request',
     });
   });
 });

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -16,6 +16,7 @@ export type Page = {
   name: string;
   enabled: boolean;
   keepEnabled: boolean;
+  showHeaderComments: boolean;
   filters: HeaderFilter[];
   headers: HeaderSetting[];
 };
@@ -60,6 +61,7 @@ const defaultPage: Page = {
   name: "Default",
   enabled: true,
   keepEnabled: false,
+  showHeaderComments: true,
   filters: [],
   headers: [
     {

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -4,6 +4,7 @@ import browser from "webextension-polyfill";
 import { SELECTED_PAGE_KEY, SETTINGS_KEY, SETTINGS_V3_META_KEY, PAGE_KEY_PREFIX, SYNC_ENABLED_KEY, MIGRATION_COMPLETE_KEY } from "../constants";
 import { saveToStorage, loadFromStorage, clearStorage, getAllFromStorage, getDataSizeInBytes } from "./storage";
 import { log } from "./log";
+import { normalizeHeader, normalizePage } from "./headers";
 
 export enum SettingsErrorType {
   None = "None",
@@ -33,6 +34,7 @@ export type HeaderSetting = {
   id: string;
   headerName: string;
   headerValue: string;
+  headerComment: string;
   headerEnabled: boolean;
   headerType: "request" | "response";
 };
@@ -64,6 +66,7 @@ const defaultPage: Page = {
       id: "default-1",
       headerName: "X-Frame-Options",
       headerValue: "ALLOW-FROM https://www.youtube.com/",
+      headerComment: "",
       headerEnabled: true,
       headerType: "request",
     },
@@ -302,19 +305,7 @@ function useFlexHeaderSettings() {
         const pagesWithNulls = await Promise.all(pagePromises);
         const pages: Page[] = pagesWithNulls
           .filter((page): page is Page => page !== null) // Remove any null/undefined pages with type guard
-          .map((page) => {
-            if (page && page.headers) {
-              // Ensure backwards compatibility for headerType
-              return {
-                ...page,
-                headers: page.headers.map((h: any) => ({
-                  ...h,
-                  headerType: h.headerType || "request",
-                }))
-              };
-            }
-            return page;
-          });
+          .map(normalizePage);
 
         if (pages.length === 0) {
           // No pages found, use default
@@ -348,13 +339,18 @@ function useFlexHeaderSettings() {
         log("SETTINGS: Migrating from v2 to v3 storage format", "info");
 
         // Migrate to new format - only save to local storage, background will handle sync
-        await saveToStorages(v2Data);
+        const normalizedV2Data = {
+          ...v2Data,
+          pages: v2Data.pages.map(normalizePage),
+        };
+
+        await saveToStorages(normalizedV2Data);
 
         // Remove old storage format
         await browser.storage.sync.remove(SETTINGS_KEY);
 
         // Set the migrated data
-        setPagesData(v2Data);
+        setPagesData(normalizedV2Data);
         setHasInitialized(true);
         return;
       }
@@ -536,6 +532,7 @@ function useFlexHeaderSettings() {
             {
               ...header,
               headerType: header.headerType || "request",
+              headerComment: header.headerComment || "",
               id: `${pageId}-${page.headers.length + 1}`,
             },
           ],
@@ -790,20 +787,14 @@ function useFlexHeaderSettings() {
         const pages = pageResults
           .map((result, index) => result[`${PAGE_KEY_PREFIX}${index}`] as Page)
           .filter(Boolean)
-          .map(page => ({
-            ...page,
-            headers: page.headers?.map((h: any) => ({
-              ...h,
-              headerType: h.headerType || "request",
-            })) || []
-          }));
+          .map(normalizePage);
         return pages.length > 0 ? pages : null;
       }
 
       // Check for legacy v2 format
       const v2Data = await browser.storage.sync.get(SETTINGS_KEY);
       if (v2Data[SETTINGS_KEY]) {
-        return (v2Data[SETTINGS_KEY] as PagesData).pages;
+        return (v2Data[SETTINGS_KEY] as PagesData).pages.map(normalizePage);
       }
 
       return null;
@@ -927,10 +918,7 @@ function useFlexHeaderSettings() {
             return {
               ...page,
               id: index,
-              headers: page.headers.map((h: any) => ({
-                ...h,
-                headerType: h.headerType ? h.headerType : "request",
-              })),
+              headers: page.headers.map(normalizeHeader),
             };
           });
 

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -103,7 +103,9 @@ function useFlexHeaderSettings() {
   const [darkModeEnabled, setDarkModeEnabled] = useState(false);
   const [syncEnabled, setSyncEnabled] = useState(false);
   const [hasInitialized, setHasInitialized] = useState(false);
+  const [saveVersion, setSaveVersion] = useState(0);
   const isSavingRef = useRef<boolean>(false);
+  const hasPendingSaveRef = useRef<boolean>(false);
 
   const alertContext = useAlert();
 
@@ -211,7 +213,12 @@ function useFlexHeaderSettings() {
 
   // Main save effect that watches for data changes
   useEffect(() => {
-    if (!hasInitialized || isSavingRef.current) return;
+    if (!hasInitialized) return;
+
+    if (isSavingRef.current) {
+      hasPendingSaveRef.current = true;
+      return;
+    }
 
     // Stringify current data for comparison
     const currentDataString = JSON.stringify(pagesData);
@@ -248,9 +255,13 @@ function useFlexHeaderSettings() {
         setTimeout(() => {
           isSavingRef.current = false;
           log("SETTINGS: Changes saved successfully", "success");
+          if (hasPendingSaveRef.current) {
+            hasPendingSaveRef.current = false;
+            setSaveVersion((version) => version + 1);
+          }
         }, 0);
       });
-  }, [pagesData, hasInitialized, lastError, saveToStorages, alertContext]);
+  }, [pagesData, hasInitialized, lastError, saveToStorages, alertContext, saveVersion]);
 
   /**
    * Loads the settings from storage and sets the state
@@ -904,38 +915,42 @@ function useFlexHeaderSettings() {
   /**
    * Import json file
    */
-  const importSettings = (file: File) => {
-    const reader = new FileReader();
-    reader.onload = (e) => {
-      const result = e.target?.result;
+  const importSettings = (file: File): Promise<void> => {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onerror = () => reject(reader.error);
+      reader.onload = (e) => {
+        const result = e.target?.result;
 
-      if (typeof result === "string") {
-        const parsed = JSON.parse(result);
-        if (Array.isArray(parsed)) {
-          // remap the ids to avoid conflicts
-          const combinedPages = [...pagesData.pages, ...parsed];
-          const newPages = combinedPages.map((page: any, index) => {
-            return {
-              ...page,
-              id: index,
-              headers: page.headers.map(normalizeHeader),
-            };
-          });
+        if (typeof result === "string") {
+          const parsed = JSON.parse(result);
+          if (Array.isArray(parsed)) {
+            // remap the ids to avoid conflicts
+            const combinedPages = [...pagesData.pages, ...parsed];
+            const newPages = combinedPages.map((page: any, index) => {
+              return {
+                ...page,
+                id: index,
+                headers: page.headers.map(normalizeHeader),
+              };
+            });
 
-          setPagesData((prev) => ({
-            ...prev,
-            pages: newPages,
-          }));
+            setPagesData((prev) => ({
+              ...prev,
+              pages: newPages,
+            }));
 
-          alertContext.setAlert({
-            alertType: "info",
-            alertText: "Settings imported.",
-            location: "bottom",
-          });
+            alertContext.setAlert({
+              alertType: "info",
+              alertText: "Settings imported.",
+              location: "bottom",
+            });
+          }
         }
-      }
-    };
-    reader.readAsText(file);
+        resolve();
+      };
+      reader.readAsText(file);
+    });
   };
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- add a per-header comment field to the header row UI
- persist comments in header settings so imports and exports preserve them
- normalize legacy imported headers with an empty comment and default request type

## Tests
- npm test -- --watchAll=false
- npm run build