### PR TITLE
remove v2 settings migration

### DIFF
--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -1,5 +1,5 @@
-import { PAGE_KEY_PREFIX, SETTINGS_V3_META_KEY, SETTINGS_KEY, SYNC_INTERVAL, LAST_SYNC_TIME_KEY, SELECTED_PAGE_KEY, SYNC_ENABLED_KEY } from "../constants";
-import type { Page, PagesData, SettingsV3Meta } from "../utils/settings";
+import { PAGE_KEY_PREFIX, SETTINGS_V3_META_KEY, SYNC_INTERVAL, LAST_SYNC_TIME_KEY, SELECTED_PAGE_KEY, SYNC_ENABLED_KEY } from "../constants";
+import type { Page, SettingsV3Meta } from "../utils/settings";
 import browser from "webextension-polyfill";
 import { getAllFromStorage, saveToStorage, getDataSizeInBytes, loadFromStorage } from "../utils/storage";
 import { log } from "../utils/log";
@@ -28,7 +28,9 @@ export async function getAndApplyHeaderRules() {
 
     let pages: Page[] = [];
 
-    if (meta) {
+    if (!meta) {
+      console.log("FlexHeader: No settings metadata found, applying empty rules");
+    } else {
       // Fetch all pages using the distributed storage format
       const pagePromises = [];
       for (let i = 0; i < meta.pageCount; i++) {
@@ -43,14 +45,6 @@ export async function getAndApplyHeaderRules() {
         })
         .filter(Boolean) // Filter out any undefined/null pages
         .map(normalizePage);
-    } else {
-      // Try legacy v2 format as fallback
-      console.log("FlexHeader: Falling back to V2 storage format");
-      const legacyResult = await browser.storage.local.get(SETTINGS_KEY);
-
-      if (legacyResult[SETTINGS_KEY]) {
-        pages = (legacyResult[SETTINGS_KEY] as PagesData).pages.map(normalizePage);
-      }
     }
 
     console.log(
@@ -140,7 +134,7 @@ export async function syncLocalToRemoteStorage() {
 
 browser.storage.local.onChanged.addListener(function (changes) {
   // Trigger update if any settings change (v3 meta or any page_* key)
-  if (SETTINGS_V3_META_KEY in changes || SETTINGS_KEY in changes ||
+  if (SETTINGS_V3_META_KEY in changes ||
     Object.keys(changes).some(key => key.startsWith(PAGE_KEY_PREFIX))) {
     getAndApplyHeaderRules();
   }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,3 @@
-export const SETTINGS_KEY = "settings_v2"; // Legacy key for migration
 export const SETTINGS_V3_META_KEY = "settings_v3_meta";
 export const PAGE_KEY_PREFIX = "page_";
 export const SELECTED_PAGE_KEY = "selectedPage";

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -2,7 +2,7 @@ import { useEffect, useState, useCallback, useRef } from "react";
 import { useAlert } from "../context/alertContext";
 import browser from "webextension-polyfill";
 import { z } from "zod";
-import { SELECTED_PAGE_KEY, SETTINGS_KEY, SETTINGS_V3_META_KEY, PAGE_KEY_PREFIX, SYNC_ENABLED_KEY, MIGRATION_COMPLETE_KEY } from "../constants";
+import { SELECTED_PAGE_KEY, SETTINGS_V3_META_KEY, PAGE_KEY_PREFIX, SYNC_ENABLED_KEY, MIGRATION_COMPLETE_KEY } from "../constants";
 import { saveToStorage, loadFromStorage, clearStorage, getAllFromStorage, getDataSizeInBytes } from "./storage";
 import { log } from "./log";
 import { normalizePage } from "./headers";
@@ -391,29 +391,6 @@ function useFlexHeaderSettings() {
           }
         }
 
-        setHasInitialized(true);
-        return;
-      }
-
-      // Check for legacy v2 format and migrate
-      const v2Data = await loadFromStorage<PagesData | null>(SETTINGS_KEY, null, ['sync']);
-
-      if (v2Data) {
-        log("SETTINGS: Migrating from v2 to v3 storage format", "info");
-
-        // Migrate to new format - only save to local storage, background will handle sync
-        const normalizedV2Data = {
-          ...v2Data,
-          pages: v2Data.pages.map(normalizePage),
-        };
-
-        await saveToStorages(normalizedV2Data);
-
-        // Remove old storage format
-        await browser.storage.sync.remove(SETTINGS_KEY);
-
-        // Set the migrated data
-        setPagesData(normalizedV2Data);
         setHasInitialized(true);
         return;
       }
@@ -852,12 +829,6 @@ function useFlexHeaderSettings() {
           .filter(Boolean)
           .map(normalizePage);
         return pages.length > 0 ? pages : null;
-      }
-
-      // Check for legacy v2 format
-      const v2Data = await browser.storage.sync.get(SETTINGS_KEY);
-      if (v2Data[SETTINGS_KEY]) {
-        return (v2Data[SETTINGS_KEY] as PagesData).pages.map(normalizePage);
       }
 
       return null;


### PR DESCRIPTION
This pull request removes all support for the legacy v2 settings storage format, streamlining the codebase to only use the current v3 settings format. This simplifies storage handling and migration logic, making the code easier to maintain and reducing complexity.

**Settings storage simplification:**

* Removed all code related to reading, migrating, or falling back to the legacy v2 settings format from both the background script (`background.ts`) and the settings utility (`settings.ts`). [[1]](diffhunk://#diff-b11fba3fe7b52728b021cbda8505a4dc695a5606d723001ac8f5ec854402cf17L46-L53) [[2]](diffhunk://#diff-07711e51b85f8675859e6b4b08b61da1fc8a14a018cc3bd49f78fd5bb77e027eL398-L420) [[3]](diffhunk://#diff-07711e51b85f8675859e6b4b08b61da1fc8a14a018cc3bd49f78fd5bb77e027eL857-L862)
* Deleted the `SETTINGS_KEY` constant, which was only used for v2 storage.

**Code cleanup and dependency updates:**

* Updated imports in `background.ts` and `settings.ts` to remove references to `SETTINGS_KEY` and unused types. [[1]](diffhunk://#diff-b11fba3fe7b52728b021cbda8505a4dc695a5606d723001ac8f5ec854402cf17L1-R2) [[2]](diffhunk://#diff-07711e51b85f8675859e6b4b08b61da1fc8a14a018cc3bd49f78fd5bb77e027eL5-R5)

**Behavioral adjustments:**

* The background script now logs a message and applies empty rules if no v3 metadata is found, instead of attempting to load legacy v2 settings.
* The settings change listener in the background script no longer checks for changes to the legacy v2 key.