### PR TITLE
Add opt-in undo/redo history for header/filter/page edits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,13 @@ changed" rot the moment the PR merges.
 - `src/utils/pageMerge.ts` — the sync/local merge logic, shared by both the
   background worker's continuous pull and the UI's one-time "enable sync"
   migration. Keep merge logic here, not duplicated in both callers.
+- `src/utils/usePageHistory.ts` — the undo/redo stack for `pagesData`
+  (recording, replaying, persisting, and reconciling it against a sync
+  merge). Extracted out of `settings.ts` so that hook stays focused on
+  settings persistence. Takes an `enabled` flag (backed by the
+  `historyEnabled` setting, toggled from the settings page) that no-ops
+  recording/undo/redo without touching whatever stack is already persisted -
+  so re-enabling later doesn't lose history collected before the toggle.
 
 ## Storage model
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import "./App.css";
 import FilterSection from "./components/filterSection";
 import AppHeader from "./components/appHeader";
@@ -10,11 +11,29 @@ import useReviewPrompt from "./utils/useReviewPrompt";
 import { isRunningInActionPopup } from "./utils/browserContext";
 import HeadersList from "./components/headersList";
 import PageTitle from "./components/pageTitle";
-import { useSettingsState } from "./context/settingsContext";
+import { useSettingsState, useSettingsActions } from "./context/settingsContext";
 
 function App() {
   const { selectedPage, currentPage, darkModeEnabled } = useSettingsState();
+  const { undo, redo } = useSettingsActions();
   const { shouldShow: shouldShowReviewPrompt, loading: reviewPromptLoading, hidePrompt } = useReviewPrompt();
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const isModifier = e.metaKey || e.ctrlKey;
+      if (!isModifier || e.key.toLowerCase() !== "z") return;
+
+      e.preventDefault();
+      if (e.shiftKey) {
+        redo();
+      } else {
+        undo();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [undo, redo]);
 
   if (!isRunningInActionPopup()) {
     return (

--- a/src/components/appHeader/index.css
+++ b/src/components/appHeader/index.css
@@ -73,6 +73,15 @@
   background-color: var(--background-tertiary);
 }
 
+.app-header__icon-button:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+
+.app-header__icon-button:disabled:hover {
+  background-color: transparent;
+}
+
 .app-header__icon-button svg,
 .app-header__icon-button img {
   width: 1.25rem;

--- a/src/components/appHeader/index.tsx
+++ b/src/components/appHeader/index.tsx
@@ -17,9 +17,9 @@ import SyncToggleButton from "../syncToggleButton";
 import { getSyncStatus } from "../../utils/syncStatus";
 
 const AppHeader = () => {
-  const { darkModeEnabled, syncEnabled, pages, errors, lastSyncTime, localModifiedTime } =
+  const { darkModeEnabled, syncEnabled, pages, errors, lastSyncTime, localModifiedTime, canUndo, canRedo } =
     useSettingsState();
-  const { toggleDarkMode, toggleSync, importSettings, clearErrors } =
+  const { toggleDarkMode, toggleSync, importSettings, clearErrors, undo, redo } =
     useSettingsActions();
   const manifest = browser.runtime.getManifest();
   const isFirefoxPopup = isRunningInActionPopup() && isFirefox();
@@ -66,6 +66,52 @@ const AppHeader = () => {
           </a>
         </div>
       </div>
+      <button
+        type="button"
+        className="app-header__icon-button"
+        onClick={undo}
+        disabled={!canUndo}
+        aria-label="Undo"
+        title="Undo (Ctrl+Z)"
+        data-testid="undo-button"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M9 14 4 9l5-5" />
+          <path d="M4 9h10.5a5.5 5.5 0 0 1 0 11H11" />
+        </svg>
+      </button>
+      <button
+        type="button"
+        className="app-header__icon-button"
+        onClick={redo}
+        disabled={!canRedo}
+        aria-label="Redo"
+        title="Redo (Ctrl+Shift+Z)"
+        data-testid="redo-button"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <path d="m15 14 5-5-5-5" />
+          <path d="M20 9H9.5a5.5 5.5 0 0 0 0 11H13" />
+        </svg>
+      </button>
       <button
         type="button"
         className="app-header__icon-button"

--- a/src/components/settingsPage/index.css
+++ b/src/components/settingsPage/index.css
@@ -35,6 +35,11 @@
   margin: 0;
 }
 
+.settings-page__section h3 {
+  font-size: 1rem;
+  margin: 0.5rem 0 0;
+}
+
 .settings-page__section p {
   margin: 0;
   font-size: 0.9rem;
@@ -55,4 +60,32 @@
 .settings-page__sync-status--pending {
   opacity: 1;
   color: var(--primary);
+}
+
+.settings-page__toggle {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  cursor: pointer;
+}
+
+.settings-page__toggle-input {
+  margin-top: 0.2rem;
+  flex-shrink: 0;
+}
+
+.settings-page__toggle-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.settings-page__toggle-title {
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.settings-page__toggle-description {
+  font-size: 0.9rem;
+  opacity: 0.9;
 }

--- a/src/components/settingsPage/index.tsx
+++ b/src/components/settingsPage/index.tsx
@@ -11,8 +11,8 @@ import { getSyncStatus } from "../../utils/syncStatus";
 import "./index.css";
 
 const SettingsPage = () => {
-  const { pages, syncEnabled, lastSyncTime, localModifiedTime } = useSettingsState();
-  const { importSettings, toggleSync, injectError, clearErrors } = useSettingsActions();
+  const { pages, syncEnabled, lastSyncTime, localModifiedTime, historyEnabled } = useSettingsState();
+  const { importSettings, toggleSync, injectError, clearErrors, toggleHistoryEnabled } = useSettingsActions();
   const syncStatus = getSyncStatus(lastSyncTime, localModifiedTime);
   return (
     <div className="settings-page">
@@ -74,6 +74,30 @@ const SettingsPage = () => {
             {syncStatus.label}
           </p>
         )}
+      </div>
+
+      <Divider />
+
+      <div className="settings-page__section">
+        <h2>Experimental Settings</h2>
+        <p>Opt-in features still under evaluation.</p>
+
+        <label className="settings-page__toggle">
+          <input
+            type="checkbox"
+            className="settings-page__toggle-input"
+            checked={historyEnabled}
+            onChange={toggleHistoryEnabled}
+            data-testid="history-toggle-button"
+          />
+          <span className="settings-page__toggle-content">
+            <span className="settings-page__toggle-title">Undo / Redo</span>
+            <span className="settings-page__toggle-description">
+              Track header, filter, and page edits so they can be undone with
+              Ctrl+Z (Ctrl+Shift+Z to redo).
+            </span>
+          </span>
+        </label>
       </div>
 
       {import.meta.env.DEV && (

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,6 +14,9 @@ export const REVIEW_PROMPT_KEY = "reviewPrompt";
 export const REVIEWS_URL = "https://chromewebstore.google.com/detail/flexheaders-modify-http-h/gffpeamhhldhibdngenbfciboinanppf/reviews?utm_source=in-extension";
 export const ISSUES_URL = "https://github.com/harrisondeo/FlexHeader/issues";
 export const ERRORS_STATE_KEY = "flexheader_errors";
+export const UNDO_STACK_KEY = "undo_stack"; // Local only - a per-device history, not shared truth
+export const REDO_STACK_KEY = "redo_stack";
+export const HISTORY_ENABLED_KEY = "history_enabled"; // Local only - per-device preference for the undo/redo feature
 
 export const POPULAR_HEADER_NAMES = [
   "Accept",

--- a/src/context/settingsContext.tsx
+++ b/src/context/settingsContext.tsx
@@ -20,6 +20,9 @@ type SettingsStateContextValue = {
   lastSyncTime: number | null;
   localModifiedTime: number | null;
   errors: AppError[];
+  canUndo: boolean;
+  canRedo: boolean;
+  historyEnabled: boolean;
 };
 
 type SettingsActionsContextValue = {
@@ -52,6 +55,9 @@ type SettingsActionsContextValue = {
   toggleSync: () => Promise<void>;
   clearErrors: (category?: AppError["category"]) => Promise<void>;
   injectError: (category?: ErrorCategory) => Promise<void>;
+  undo: () => void;
+  redo: () => void;
+  toggleHistoryEnabled: () => Promise<void>;
 };
 
 const SettingsStateContext = createContext<SettingsStateContextValue | null>(
@@ -81,6 +87,9 @@ export const SettingsProvider = ({ children }: { children: ReactNode }) => {
       lastSyncTime: settings.lastSyncTime,
       localModifiedTime: settings.localModifiedTime,
       errors: settings.errors,
+      canUndo: settings.canUndo,
+      canRedo: settings.canRedo,
+      historyEnabled: settings.historyEnabled,
     }),
     [
       settings.pages,
@@ -91,6 +100,9 @@ export const SettingsProvider = ({ children }: { children: ReactNode }) => {
       settings.lastSyncTime,
       settings.localModifiedTime,
       settings.errors,
+      settings.canUndo,
+      settings.canRedo,
+      settings.historyEnabled,
     ]
   );
 
@@ -113,6 +125,9 @@ export const SettingsProvider = ({ children }: { children: ReactNode }) => {
       toggleSync: settings.toggleSync,
       clearErrors: settings.clearErrors,
       injectError: settings.injectError,
+      undo: settings.undo,
+      redo: settings.redo,
+      toggleHistoryEnabled: settings.toggleHistoryEnabled,
     }),
     [
       settings.addHeader,
@@ -132,6 +147,9 @@ export const SettingsProvider = ({ children }: { children: ReactNode }) => {
       settings.toggleSync,
       settings.clearErrors,
       settings.injectError,
+      settings.undo,
+      settings.redo,
+      settings.toggleHistoryEnabled,
     ]
   );
 

--- a/src/utils/pageMerge.ts
+++ b/src/utils/pageMerge.ts
@@ -1,4 +1,4 @@
-import type { Page } from "./settings";
+import type { Page, PagesData } from "./settings";
 import { TOMBSTONE_RETENTION_MS } from "../constants";
 
 export interface PageTombstone {
@@ -213,4 +213,55 @@ export const mergeSyncState = (
     pages: finalPages,
     tombstones: mergedTombstones,
   };
+};
+
+const stripLastModified = (page: Page): string =>
+  JSON.stringify(page, (key, value) => (key === "lastModified" ? undefined : value));
+
+/**
+ * A stack entry is unsafe to restore once any page it holds either got
+ * tombstoned since the snapshot was taken, or was edited remotely with a
+ * newer `lastModified` than the snapshot has - restoring it would silently
+ * revert that remote change (the same class of bug fresh edits avoid via
+ * settings.ts's stampChangedPages). Pages without a `pageId` predate the
+ * migration and can't be tracked across a merge, so are treated as stale
+ * rather than risk silently reverting one.
+ */
+const isHistorySnapshotStale = (
+  snapshot: PagesData,
+  mergedPages: Page[],
+  tombstones: PageTombstone[]
+): boolean => {
+  const mergedByPageId = new Map(mergedPages.filter((p) => p.pageId).map((p) => [p.pageId as string, p]));
+  const deletedAtByPageId = new Map(tombstones.map((t) => [t.pageId, t.deletedAt]));
+
+  return snapshot.pages.some((page) => {
+    if (!page.pageId) return true;
+
+    const deletedAt = deletedAtByPageId.get(page.pageId);
+    if (deletedAt !== undefined && deletedAt > (page.lastModified ?? 0)) return true;
+
+    const merged = mergedByPageId.get(page.pageId);
+    if (!merged) return true;
+
+    return (
+      (merged.lastModified ?? 0) > (page.lastModified ?? 0) &&
+      stripLastModified(merged) !== stripLastModified(page)
+    );
+  });
+};
+
+/**
+ * Drops only the undo/redo entries a merge actually invalidated, instead of
+ * wiping the whole stack. Each entry is a self-contained full-state
+ * snapshot rather than a diff, so dropping one out of the middle never
+ * breaks the entries around it.
+ */
+export const reconcileHistoryAfterMerge = (
+  stack: PagesData[],
+  mergedPages: Page[],
+  tombstones: PageTombstone[]
+): PagesData[] => {
+  const reconciled = stack.filter((snapshot) => !isHistorySnapshotStale(snapshot, mergedPages, tombstones));
+  return reconciled.length === stack.length ? stack : reconciled;
 };

--- a/src/utils/settings.test.ts
+++ b/src/utils/settings.test.ts
@@ -52,9 +52,10 @@ import {
   pruneExpiredTombstones,
   createTombstone,
   synthesizeFallbackPage,
+  reconcileHistoryAfterMerge,
   type PageTombstone,
 } from './pageMerge';
-import { TOMBSTONE_RETENTION_MS } from '../constants';
+import { TOMBSTONE_RETENTION_MS, HISTORY_ENABLED_KEY } from '../constants';
 
 // Helper functions to create test data
 const createHeader = (name: string, value: string, enabled = true): HeaderSetting => ({
@@ -575,6 +576,78 @@ describe('Tombstone-aware merge (mergeSyncState)', () => {
   });
 });
 
+describe('reconcileHistoryAfterMerge', () => {
+  const withIdentity = (page: Page, pageId: string, lastModified: number): Page => ({
+    ...page,
+    pageId,
+    lastModified,
+  });
+  const tombstone = (pageId: string, deletedAt: number): PageTombstone => ({ pageId, deletedAt });
+  const snapshot = (...pages: Page[]) => ({ pages, selectedPage: pages[0]?.id ?? 0 });
+
+  it('keeps a stack entry whose pages the merge never touched', () => {
+    const untouched = withIdentity(createPage(0, 'Work', true), 'page-1', 1000);
+    const stack = [snapshot(untouched)];
+
+    const result = reconcileHistoryAfterMerge(stack, [untouched], []);
+    expect(result).toBe(stack);
+  });
+
+  it('drops an entry whose page was tombstoned by the merge', () => {
+    const deleted = withIdentity(createPage(0, 'Work', true), 'page-1', 1000);
+    const stack = [snapshot(deleted)];
+
+    const result = reconcileHistoryAfterMerge(stack, [], [tombstone('page-1', 2000)]);
+    expect(result).toHaveLength(0);
+  });
+
+  it('drops an entry whose page was edited remotely with a newer lastModified than the snapshot holds', () => {
+    const stale = withIdentity(createPage(0, 'Work', true, [createHeader('X-Auth', 'old')]), 'page-1', 1000);
+    const mergedRemote = withIdentity(createPage(0, 'Work', true, [createHeader('X-Auth', 'new')]), 'page-1', 2000);
+    const stack = [snapshot(stale)];
+
+    const result = reconcileHistoryAfterMerge(stack, [mergedRemote], []);
+    expect(result).toHaveLength(0);
+  });
+
+  it('keeps an entry whose page is newer remotely but content-identical (no real conflict)', () => {
+    const header = createHeader('X-Auth', 'same');
+    const local = withIdentity(createPage(0, 'Work', true, [header]), 'page-1', 1000);
+    const mergedRemote = withIdentity(createPage(0, 'Work', true, [header]), 'page-1', 2000);
+    const stack = [snapshot(local)];
+
+    const result = reconcileHistoryAfterMerge(stack, [mergedRemote], []);
+    expect(result).toHaveLength(1);
+  });
+
+  it('keeps entries for unaffected pages while dropping only the conflicting one', () => {
+    const unaffected = withIdentity(createPage(0, 'Home', true), 'page-1', 1000);
+    const deleted = withIdentity(createPage(1, 'Old Page', true), 'page-2', 1000);
+
+    const goodEntry = snapshot(unaffected);
+    const badEntry = { pages: [unaffected, deleted], selectedPage: 0 };
+    const stack = [goodEntry, badEntry];
+
+    const result = reconcileHistoryAfterMerge(stack, [unaffected], [tombstone('page-2', 2000)]);
+    expect(result).toEqual([goodEntry]);
+  });
+
+  it('treats a legacy page with no pageId as stale rather than risk restoring it', () => {
+    const legacy = createPage(0, 'Work', true); // no pageId
+    const stack = [snapshot(legacy)];
+
+    const result = reconcileHistoryAfterMerge(stack, [legacy], []);
+    expect(result).toHaveLength(0);
+  });
+
+  it('is a no-op (same reference) when nothing in the stack is invalidated', () => {
+    const page = withIdentity(createPage(0, 'Work', true), 'page-1', 1000);
+    const stack = [snapshot(page)];
+
+    expect(reconcileHistoryAfterMerge(stack, [page], [])).toBe(stack);
+  });
+});
+
 describe('URL filter validation', () => {
   it('accepts common valid URL patterns', () => {
     expect(isValidUrlFilter('||example.com/')).toBe(true);
@@ -872,5 +945,333 @@ describe('Page identity is never reused when a page is added or imported', () =>
     await waitFor(() => expect(result.current.pages.length).toBe(2));
     const pageIds = result.current.pages.map((p) => p.pageId);
     expect(new Set(pageIds).size).toBe(pageIds.length); // no duplicates
+  });
+});
+
+describe('Undo/redo history', () => {
+  const createStorageArea = () => {
+    const store: Record<string, any> = {};
+    return {
+      store,
+      get: vi.fn(async (key?: string | string[] | null) => {
+        if (key === undefined || key === null) return { ...store };
+        if (typeof key === 'string') return { [key]: store[key] };
+        const result: Record<string, any> = {};
+        key.forEach((k) => { result[k] = store[k]; });
+        return result;
+      }),
+      set: vi.fn(async (data: Record<string, any>) => { Object.assign(store, data); }),
+      remove: vi.fn(async (keys: string | string[]) => {
+        const arr = Array.isArray(keys) ? keys : [keys];
+        arr.forEach((k) => delete store[k]);
+      }),
+    };
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const local = createStorageArea();
+    const sync = createStorageArea();
+
+    browserMock.storage.local.get.mockImplementation(local.get);
+    browserMock.storage.local.set.mockImplementation(local.set);
+    browserMock.storage.local.remove.mockImplementation(local.remove);
+    browserMock.storage.local.onChanged.addListener.mockImplementation(() => {});
+    browserMock.storage.sync.get.mockImplementation(sync.get);
+    browserMock.storage.sync.set.mockImplementation(sync.set);
+    browserMock.storage.sync.remove.mockImplementation(sync.remove);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('collapses a rapid burst of header edits (e.g. keystrokes) into a single undo step', async () => {
+    const { result } = renderHook(() => useFlexHeaderSettings());
+    await waitFor(() => expect(result.current.pages.length).toBeGreaterThan(0));
+
+    const pageId = result.current.selectedPage;
+    const header = result.current.pages[0].headers[0];
+    const originalValue = header.headerValue;
+
+    vi.useFakeTimers();
+
+    act(() => {
+      result.current.updateHeader(pageId, { ...header, headerValue: 'a' });
+    });
+    act(() => {
+      vi.advanceTimersByTime(100);
+      result.current.updateHeader(pageId, { ...header, headerValue: 'ab' });
+    });
+    act(() => {
+      vi.advanceTimersByTime(100);
+      result.current.updateHeader(pageId, { ...header, headerValue: 'abc' });
+    });
+
+    expect(result.current.pages[0].headers[0].headerValue).toBe('abc');
+    expect(result.current.canUndo).toBe(true);
+
+    act(() => {
+      result.current.undo();
+    });
+
+    expect(result.current.pages[0].headers[0].headerValue).toBe(originalValue);
+    expect(result.current.canUndo).toBe(false);
+  });
+
+  it('starts a new undo step once the debounce window has elapsed between edits', async () => {
+    const { result } = renderHook(() => useFlexHeaderSettings());
+    await waitFor(() => expect(result.current.pages.length).toBeGreaterThan(0));
+
+    const pageId = result.current.selectedPage;
+    const header = result.current.pages[0].headers[0];
+    const originalValue = header.headerValue;
+
+    vi.useFakeTimers();
+
+    act(() => {
+      result.current.updateHeader(pageId, { ...header, headerValue: 'a' });
+    });
+    act(() => {
+      // Past HISTORY_DEBOUNCE_MS - the previous burst has closed.
+      vi.advanceTimersByTime(600);
+      result.current.updateHeader(pageId, { ...header, headerValue: 'ab' });
+    });
+
+    act(() => {
+      result.current.undo();
+    });
+    expect(result.current.pages[0].headers[0].headerValue).toBe('a');
+
+    act(() => {
+      result.current.undo();
+    });
+    expect(result.current.pages[0].headers[0].headerValue).toBe(originalValue);
+  });
+
+  it('records a header deletion as its own undo step, separate from an edit made just before it', async () => {
+    const { result } = renderHook(() => useFlexHeaderSettings());
+    await waitFor(() => expect(result.current.pages.length).toBeGreaterThan(0));
+
+    const pageId = result.current.selectedPage;
+    const header = result.current.pages[0].headers[0];
+
+    act(() => {
+      result.current.updateHeader(pageId, { ...header, headerValue: 'edited' });
+    });
+    act(() => {
+      result.current.removeHeader(pageId, header.id);
+    });
+
+    expect(result.current.pages[0].headers.length).toBe(0);
+
+    act(() => {
+      result.current.undo();
+    });
+    expect(result.current.pages[0].headers.length).toBe(1);
+    expect(result.current.pages[0].headers[0].headerValue).toBe('edited');
+
+    act(() => {
+      result.current.undo();
+    });
+    expect(result.current.pages[0].headers[0].headerValue).toBe(header.headerValue);
+  });
+
+  it('redo re-applies an undone change', async () => {
+    const { result } = renderHook(() => useFlexHeaderSettings());
+    await waitFor(() => expect(result.current.pages.length).toBeGreaterThan(0));
+
+    const pageId = result.current.selectedPage;
+    const header = result.current.pages[0].headers[0];
+
+    act(() => {
+      result.current.updateHeader(pageId, { ...header, headerValue: 'edited' });
+    });
+    act(() => {
+      result.current.undo();
+    });
+    expect(result.current.pages[0].headers[0].headerValue).toBe(header.headerValue);
+    expect(result.current.canRedo).toBe(true);
+
+    act(() => {
+      result.current.redo();
+    });
+    expect(result.current.pages[0].headers[0].headerValue).toBe('edited');
+    expect(result.current.canRedo).toBe(false);
+  });
+
+  it('a new edit clears the redo stack', async () => {
+    const { result } = renderHook(() => useFlexHeaderSettings());
+    await waitFor(() => expect(result.current.pages.length).toBeGreaterThan(0));
+
+    const pageId = result.current.selectedPage;
+    const header = result.current.pages[0].headers[0];
+
+    act(() => {
+      result.current.updateHeader(pageId, { ...header, headerValue: 'edited' });
+    });
+    act(() => {
+      result.current.undo();
+    });
+    expect(result.current.canRedo).toBe(true);
+
+    act(() => {
+      result.current.updateHeader(pageId, { ...header, headerValue: 'something else' });
+    });
+    expect(result.current.canRedo).toBe(false);
+  });
+
+  it('undoes a page rename', async () => {
+    const { result } = renderHook(() => useFlexHeaderSettings());
+    await waitFor(() => expect(result.current.pages.length).toBeGreaterThan(0));
+
+    const page = result.current.pages[0];
+    const originalName = page.name;
+
+    act(() => {
+      result.current.updatePage({ ...page, name: 'Renamed Page' });
+    });
+    expect(result.current.pages[0].name).toBe('Renamed Page');
+
+    act(() => {
+      result.current.undo();
+    });
+    expect(result.current.pages[0].name).toBe(originalName);
+  });
+
+  it('records a filter deletion as an undoable step', async () => {
+    const { result } = renderHook(() => useFlexHeaderSettings());
+    await waitFor(() => expect(result.current.pages.length).toBeGreaterThan(0));
+
+    const pageId = result.current.selectedPage;
+
+    act(() => {
+      result.current.addFilter(pageId, { enabled: true, valid: true, type: 'include', mode: 'url', value: '||example.com/' });
+    });
+    await waitFor(() => expect(result.current.pages[0].filters.length).toBe(1));
+    const filter = result.current.pages[0].filters[0];
+
+    act(() => {
+      result.current.removeFilter(pageId, filter.id);
+    });
+    expect(result.current.pages[0].filters.length).toBe(0);
+
+    act(() => {
+      result.current.undo();
+    });
+    expect(result.current.pages[0].filters.length).toBe(1);
+  });
+
+  it('has nothing to undo/redo on a fresh load', async () => {
+    const { result } = renderHook(() => useFlexHeaderSettings());
+    await waitFor(() => expect(result.current.pages.length).toBeGreaterThan(0));
+
+    expect(result.current.canUndo).toBe(false);
+    expect(result.current.canRedo).toBe(false);
+  });
+
+  it('bumps lastModified on undo so a sync merge does not resurrect the undone edit', async () => {
+    const { result } = renderHook(() => useFlexHeaderSettings());
+    await waitFor(() => expect(result.current.pages.length).toBeGreaterThan(0));
+
+    const pageId = result.current.selectedPage;
+    const header = result.current.pages[0].headers[0];
+
+    act(() => {
+      result.current.updateHeader(pageId, { ...header, headerValue: 'edited' });
+    });
+    // Simulates the edit above having already reached sync storage (e.g. a
+    // background push that raced with the undo below) before the undo runs.
+    const pushedToSync = result.current.pages;
+
+    act(() => {
+      result.current.undo();
+    });
+    expect(result.current.pages[0].headers[0].headerValue).toBe(header.headerValue);
+
+    // A merge landing right after the undo must not treat the older-looking
+    // undone snapshot as stale and reapply the edit it just reverted.
+    const merged = mergePages(result.current.pages, pushedToSync);
+    expect(merged).toBe(result.current.pages);
+    expect(merged[0].headers[0].headerValue).toBe(header.headerValue);
+  });
+});
+
+describe('Undo/redo history toggle', () => {
+  const createStorageArea = () => {
+    const store: Record<string, any> = {};
+    return {
+      store,
+      get: vi.fn(async (key?: string | string[] | null) => {
+        if (key === undefined || key === null) return { ...store };
+        if (typeof key === 'string') return { [key]: store[key] };
+        const result: Record<string, any> = {};
+        key.forEach((k) => { result[k] = store[k]; });
+        return result;
+      }),
+      set: vi.fn(async (data: Record<string, any>) => { Object.assign(store, data); }),
+      remove: vi.fn(async (keys: string | string[]) => {
+        const arr = Array.isArray(keys) ? keys : [keys];
+        arr.forEach((k) => delete store[k]);
+      }),
+    };
+  };
+
+  let local: ReturnType<typeof createStorageArea>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    local = createStorageArea();
+    const sync = createStorageArea();
+
+    browserMock.storage.local.get.mockImplementation(local.get);
+    browserMock.storage.local.set.mockImplementation(local.set);
+    browserMock.storage.local.remove.mockImplementation(local.remove);
+    browserMock.storage.local.onChanged.addListener.mockImplementation(() => {});
+    browserMock.storage.sync.get.mockImplementation(sync.get);
+    browserMock.storage.sync.set.mockImplementation(sync.set);
+    browserMock.storage.sync.remove.mockImplementation(sync.remove);
+  });
+
+  it('is enabled by default', async () => {
+    const { result } = renderHook(() => useFlexHeaderSettings());
+    await waitFor(() => expect(result.current.pages.length).toBeGreaterThan(0));
+
+    expect(result.current.historyEnabled).toBe(true);
+  });
+
+  it('toggleHistoryEnabled flips state and persists the preference to local storage', async () => {
+    const { result } = renderHook(() => useFlexHeaderSettings());
+    await waitFor(() => expect(result.current.pages.length).toBeGreaterThan(0));
+
+    await act(async () => {
+      await result.current.toggleHistoryEnabled();
+    });
+
+    expect(result.current.historyEnabled).toBe(false);
+    expect(local.store[HISTORY_ENABLED_KEY]).toBe(false);
+  });
+
+  it('stops recording and blocks undo/redo once disabled', async () => {
+    const { result } = renderHook(() => useFlexHeaderSettings());
+    await waitFor(() => expect(result.current.pages.length).toBeGreaterThan(0));
+
+    await act(async () => {
+      await result.current.toggleHistoryEnabled();
+    });
+
+    const pageId = result.current.selectedPage;
+    const header = result.current.pages[0].headers[0];
+
+    act(() => {
+      result.current.updateHeader(pageId, { ...header, headerValue: 'edited' });
+    });
+
+    expect(result.current.canUndo).toBe(false);
+
+    act(() => {
+      result.current.undo();
+    });
+    expect(result.current.pages[0].headers[0].headerValue).toBe('edited');
   });
 });

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -2,13 +2,14 @@ import { useEffect, useState, useCallback, useRef } from "react";
 import { useAlert } from "../context/alertContext";
 import browser from "webextension-polyfill";
 import { z } from "zod";
-import { SETTINGS_V3_META_KEY, PAGE_KEY_PREFIX, PAGE_TOMBSTONES_KEY, SYNC_ENABLED_KEY, ERRORS_STATE_KEY, LAST_MERGE_TIME_KEY, LAST_SYNC_TIME_KEY, LOCAL_MODIFIED_TIME_KEY } from "../constants";
+import { SETTINGS_V3_META_KEY, PAGE_KEY_PREFIX, PAGE_TOMBSTONES_KEY, SYNC_ENABLED_KEY, ERRORS_STATE_KEY, LAST_MERGE_TIME_KEY, LAST_SYNC_TIME_KEY, LOCAL_MODIFIED_TIME_KEY, HISTORY_ENABLED_KEY } from "../constants";
 import { saveToStorage, loadFromStorage, clearStorage, getAllFromStorage, getDataSizeInBytes } from "./storage";
 import { log } from "./log";
 import { normalizePage } from "./headers";
 import { mergeSyncState, createTombstone, synthesizeFallbackPage, applyTombstones, pruneExpiredTombstones, type PageTombstone } from "./pageMerge";
 import { readPageStorage } from "./pageStorage";
 import { AppError, addStoredError, clearStoredErrors, getStoredErrors, injectTestError, ErrorCategory } from "./errors";
+import usePageHistory from "./usePageHistory";
 
 export enum SettingsErrorType {
   None = "None",
@@ -181,7 +182,20 @@ function useFlexHeaderSettings() {
   const [localModifiedTime, setLocalModifiedTime] = useState<number | null>(null);
   const isSavingRef = useRef<boolean>(false);
   const hasPendingSaveRef = useRef<boolean>(false);
+  const [historyEnabled, setHistoryEnabled] = useState(true);
   const alertContext = useAlert();
+
+  const {
+    recordHistory,
+    undo,
+    redo,
+    canUndo,
+    canRedo,
+    resetHistory,
+    clearPendingBursts,
+    loadPersistedHistory,
+    reconcileAfterMerge,
+  } = usePageHistory({ enabled: historyEnabled, pagesData, setPagesData, hasInitialized });
 
   /**
    * Handles saving data to local storage and manages cleanup of extra pages
@@ -347,8 +361,25 @@ function useFlexHeaderSettings() {
 
   /**
    * Loads the settings from storage and sets the state
+   * @param isExternalReload True when triggered by the LAST_MERGE_TIME_KEY
+   * listener (a background sync merge landed), as opposed to the initial
+   * mount call - only that case should reconcile undo/redo history, since
+   * retrieveSettings's identity (and so the mount effect that calls it) gets
+   * recreated on unrelated re-renders too (it depends on alertContext via
+   * saveToStorages, and alertContext changes on every alert), which would
+   * otherwise touch history after almost any user action that shows a toast.
    */
-  const retrieveSettings = useCallback(async () => {
+  const retrieveSettings = useCallback(async (isExternalReload = false) => {
+    if (isExternalReload) {
+      // A (re)load replaces pagesData wholesale from an external source. Any
+      // in-flight debounce burst was keyed against the pre-reload pagesData,
+      // so drop it - undo/redo history itself is reconciled below, once the
+      // merged pages/tombstones are known, since a merge only invalidates
+      // the specific stack entries whose pages it actually touched or
+      // removed (see reconcileHistoryAfterMerge in usePageHistory).
+      clearPendingBursts();
+    }
+
     // Load dark mode setting - local only. This is a per-device preference
     // (a user may want dark mode on one browser and light on another), not
     // shared truth, so it's never synced (see background.ts's
@@ -371,6 +402,22 @@ function useFlexHeaderSettings() {
       setSyncEnabled(syncEnabledValue);
     } catch (error) {
       console.error("Failed to load sync preference:", error);
+    }
+
+    // Load undo/redo feature preference - local only, per-device.
+    try {
+      const historyEnabledValue = await loadFromStorage(HISTORY_ENABLED_KEY, true, ['local']);
+      setHistoryEnabled(historyEnabledValue);
+    } catch (error) {
+      console.error("Failed to load undo/redo history preference:", error);
+    }
+
+    // Restore undo/redo history - local only, per-device (see UNDO_STACK_KEY).
+    // Skipped on an external reload: that path reconciles the in-memory
+    // stacks (already restored at mount) against the merge instead, via
+    // reconcileAfterMerge below.
+    if (!isExternalReload) {
+      await loadPersistedHistory();
     }
 
     try {
@@ -421,6 +468,10 @@ function useFlexHeaderSettings() {
 
         setTombstones(loadedTombstones);
 
+        if (isExternalReload) {
+          reconcileAfterMerge(pages, loadedTombstones);
+        }
+
         if (pages.length === 0) {
           // No pages found, use default
           setPagesData({
@@ -453,6 +504,12 @@ function useFlexHeaderSettings() {
         selectedPage: defaultPage.id,
       });
       setTombstones([]);
+      // No merged-pages info to reconcile history against here - fall back
+      // to the old conservative wipe rather than risk restoring a snapshot
+      // for pages that turn out not to exist.
+      if (isExternalReload) {
+        resetHistory();
+      }
       setHasInitialized(true);
 
     } catch (error) {
@@ -474,6 +531,9 @@ function useFlexHeaderSettings() {
         selectedPage: defaultPage.id,
       });
       setTombstones([]);
+      if (isExternalReload) {
+        resetHistory();
+      }
       setHasInitialized(true);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -491,6 +551,7 @@ function useFlexHeaderSettings() {
       selectedPage: defaultPage.id,
     });
     setTombstones([]);
+    resetHistory();
   };
 
   /**
@@ -573,6 +634,8 @@ function useFlexHeaderSettings() {
    * @param page The page object to update
    */
   const updatePage = (page: Page) => {
+    recordHistory(`page:${page.id}`);
+
     const newPages = pagesData.pages.map((p) => (p.id === page.id ? { ...page, lastModified: Date.now() } : p));
 
     setPagesData((prev) => ({
@@ -676,6 +739,8 @@ function useFlexHeaderSettings() {
    * @param id The id of the header to remove
    */
   const removeHeader = (pageId: number, id: string) => {
+    recordHistory(null);
+
     const newPages = pagesData.pages.map((page) =>
       page.id === pageId
         ? {
@@ -719,6 +784,8 @@ function useFlexHeaderSettings() {
    * @param header The new header object, the id should match the header to update
    */
   const updateHeader = (pageId: number, header: HeaderSetting) => {
+    recordHistory(`header:${pageId}:${header.id}`);
+
     const newPages = pagesData.pages.map((page) =>
       page.id === pageId
         ? {
@@ -770,6 +837,8 @@ function useFlexHeaderSettings() {
    * @param filterId | The id of the filter to remove
    */
   const removeFilter = (pageId: number, filterId: string) => {
+    recordHistory(null);
+
     const newPages = pagesData.pages.map((page) =>
       page.id === pageId
         ? {
@@ -795,6 +864,8 @@ function useFlexHeaderSettings() {
     pageId: number,
     filter: Omit<HeaderFilter, "valid">
   ) => {
+    recordHistory(`filter:${pageId}:${filter.id}`);
+
     filterIsValid(filter, (result) => {
       const newPages = pagesData.pages.map((page) =>
         page.id === pageId
@@ -828,6 +899,20 @@ function useFlexHeaderSettings() {
       setDarkModeEnabled(newDarkMode);
     } catch (error) {
       console.error("Error toggling dark mode:", error);
+    }
+  };
+
+  /**
+   * Toggle the undo/redo history feature on or off (per-device preference).
+   */
+  const toggleHistoryEnabled = async () => {
+    try {
+      const newHistoryEnabled = !historyEnabled;
+
+      await saveToStorage(HISTORY_ENABLED_KEY, newHistoryEnabled, 'local');
+      setHistoryEnabled(newHistoryEnabled);
+    } catch (error) {
+      console.error("Error toggling undo/redo history:", error);
     }
   };
 
@@ -877,6 +962,9 @@ function useFlexHeaderSettings() {
           }
           selectedPage = newSelectedPage;
 
+          // An externally-merged view, not a user edit - clear history so
+          // undo can't revert back through a cross-browser merge.
+          resetHistory();
           setPagesData({ pages: merged.pages, selectedPage });
         }
 
@@ -1064,7 +1152,7 @@ function useFlexHeaderSettings() {
     const listener = (changes: Record<string, browser.Storage.StorageChange>) => {
       if (LAST_MERGE_TIME_KEY in changes) {
         log("SETTINGS: Detected changes merged in from sync storage, reloading", "info");
-        retrieveSettings();
+        retrieveSettings(true);
       }
     };
 
@@ -1111,6 +1199,12 @@ function useFlexHeaderSettings() {
     importSettings,
     toggleDarkMode,
     toggleSync,
+    historyEnabled,
+    toggleHistoryEnabled,
+    undo,
+    redo,
+    canUndo,
+    canRedo,
   };
 }
 

--- a/src/utils/usePageHistory.ts
+++ b/src/utils/usePageHistory.ts
@@ -1,0 +1,179 @@
+import { useEffect, useRef, useState, type Dispatch, type SetStateAction } from "react";
+import { saveToStorage, loadFromStorage } from "./storage";
+import { UNDO_STACK_KEY, REDO_STACK_KEY } from "../constants";
+import { reconcileHistoryAfterMerge, type PageTombstone } from "./pageMerge";
+import type { Page, PagesData } from "./settings";
+
+// How long an edit burst (e.g. a run of keystrokes) can pause before the next
+// change starts a new undo step, so backspacing through a whole value only
+// costs one undo instead of one per character.
+const HISTORY_DEBOUNCE_MS = 500;
+const MAX_HISTORY_ENTRIES = 50;
+
+interface UsePageHistoryParams {
+  enabled: boolean;
+  pagesData: PagesData;
+  setPagesData: Dispatch<SetStateAction<PagesData>>;
+  hasInitialized: boolean;
+}
+
+/**
+ * Owns the undo/redo stacks for `pagesData` - recording pre-change snapshots,
+ * replaying them, persisting them across popup close, and reconciling them
+ * against a background sync merge. Extracted out of useFlexHeaderSettings so
+ * that hook stays focused on settings persistence; this one owns page-state
+ * history specifically.
+ */
+function usePageHistory({ enabled, pagesData, setPagesData, hasInitialized }: UsePageHistoryParams) {
+  const [undoStack, setUndoStack] = useState<PagesData[]>([]);
+  const [redoStack, setRedoStack] = useState<PagesData[]>([]);
+  const historyBurstsRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+
+  const clearPendingBursts = () => {
+    historyBurstsRef.current.forEach((timer) => clearTimeout(timer));
+    historyBurstsRef.current.clear();
+  };
+
+  /**
+   * Records the pre-change snapshot onto the undo stack, clearing any redo
+   * history (a new edit invalidates the old redo branch). Pass a
+   * `debounceKey` for edits that fire on every keystroke (header/filter
+   * value changes, page renames) - repeated calls with the same key within
+   * HISTORY_DEBOUNCE_MS collapse into the single snapshot from the start of
+   * the burst. Pass null for discrete one-shot actions (deletions), which
+   * always record immediately.
+   */
+  const recordHistory = (debounceKey: string | null) => {
+    if (!enabled) return;
+
+    if (debounceKey) {
+      const bursts = historyBurstsRef.current;
+      const existingTimer = bursts.get(debounceKey);
+      if (existingTimer) {
+        clearTimeout(existingTimer);
+        bursts.set(debounceKey, setTimeout(() => bursts.delete(debounceKey), HISTORY_DEBOUNCE_MS));
+        return;
+      }
+      bursts.set(debounceKey, setTimeout(() => bursts.delete(debounceKey), HISTORY_DEBOUNCE_MS));
+    }
+
+    setUndoStack((prev) => [...prev, pagesData].slice(-MAX_HISTORY_ENTRIES));
+    setRedoStack([]);
+  };
+
+  /**
+   * A restored snapshot carries whatever `lastModified` its pages had back
+   * when the snapshot was taken - older than the edit(s) being undone/redone.
+   * Left as-is, a sync merge landing afterwards compares that stale
+   * timestamp against the newer one still sitting in sync storage and picks
+   * the newer side, silently reapplying the very edit the user just
+   * undid (or re-discarding the one they just redid). Stamping a fresh
+   * `lastModified` on whichever pages actually differ from the state being
+   * moved away from makes undo/redo behave like any other edit for merge
+   * purposes: the change just made locally is the newest one.
+   */
+  const stampChangedPages = (fromPages: Page[], toPages: Page[]): Page[] => {
+    const stripModified = (page: Page) =>
+      JSON.stringify(page, (key, value) => (key === "lastModified" ? undefined : value));
+    const fromByKey = new Map(fromPages.map((p) => [p.pageId ?? p.id, p]));
+
+    return toPages.map((page) => {
+      const previousVersion = fromByKey.get(page.pageId ?? page.id);
+      if (!previousVersion || stripModified(previousVersion) === stripModified(page)) {
+        return page;
+      }
+      return { ...page, lastModified: Date.now() };
+    });
+  };
+
+  const undo = () => {
+    if (!enabled || undoStack.length === 0) return;
+    clearPendingBursts();
+
+    const previous = undoStack[undoStack.length - 1];
+    setUndoStack((prev) => prev.slice(0, -1));
+    setRedoStack((prev) => [...prev, pagesData].slice(-MAX_HISTORY_ENTRIES));
+    setPagesData({ ...previous, pages: stampChangedPages(pagesData.pages, previous.pages) });
+  };
+
+  const redo = () => {
+    if (!enabled || redoStack.length === 0) return;
+    clearPendingBursts();
+
+    const next = redoStack[redoStack.length - 1];
+    setRedoStack((prev) => prev.slice(0, -1));
+    setUndoStack((prev) => [...prev, pagesData].slice(-MAX_HISTORY_ENTRIES));
+    setPagesData({ ...next, pages: stampChangedPages(pagesData.pages, next.pages) });
+  };
+
+  /** Drops pending debounce timers without touching the stacks themselves. */
+  const resetHistory = () => {
+    clearPendingBursts();
+    setUndoStack([]);
+    setRedoStack([]);
+  };
+
+  /** Restores persisted stacks from storage - the initial-mount load path only. */
+  const loadPersistedHistory = async () => {
+    try {
+      const [savedUndoStack, savedRedoStack] = await Promise.all([
+        loadFromStorage<PagesData[]>(UNDO_STACK_KEY, [], ['local']),
+        loadFromStorage<PagesData[]>(REDO_STACK_KEY, [], ['local']),
+      ]);
+      setUndoStack(savedUndoStack);
+      setRedoStack(savedRedoStack);
+    } catch (error) {
+      console.error("Failed to load undo/redo history:", error);
+    }
+  };
+
+  /**
+   * Drops only the stack entries a background sync merge actually
+   * invalidated (see reconcileHistoryAfterMerge), instead of wiping
+   * everything - the external-reload path.
+   */
+  const reconcileAfterMerge = (mergedPages: Page[], tombstones: PageTombstone[]) => {
+    setUndoStack((prev) => reconcileHistoryAfterMerge(prev, mergedPages, tombstones));
+    setRedoStack((prev) => reconcileHistoryAfterMerge(prev, mergedPages, tombstones));
+  };
+
+  useEffect(() => {
+    const bursts = historyBurstsRef.current;
+    return () => {
+      bursts.forEach((timer) => clearTimeout(timer));
+      bursts.clear();
+    };
+  }, []);
+
+  // Persist undo/redo history so it survives the popup closing (its state
+  // would otherwise live only in memory and vanish on reopen). Gated on
+  // hasInitialized so the empty initial stacks don't overwrite what's
+  // already in storage before it's been restored.
+  useEffect(() => {
+    if (!hasInitialized) return;
+    saveToStorage(UNDO_STACK_KEY, undoStack, 'local').catch((error) => {
+      console.error("Failed to persist undo history:", error);
+    });
+  }, [undoStack, hasInitialized]);
+
+  useEffect(() => {
+    if (!hasInitialized) return;
+    saveToStorage(REDO_STACK_KEY, redoStack, 'local').catch((error) => {
+      console.error("Failed to persist redo history:", error);
+    });
+  }, [redoStack, hasInitialized]);
+
+  return {
+    recordHistory,
+    undo,
+    redo,
+    canUndo: enabled && undoStack.length > 0,
+    canRedo: enabled && redoStack.length > 0,
+    resetHistory,
+    clearPendingBursts,
+    loadPersistedHistory,
+    reconcileAfterMerge,
+  };
+}
+
+export default usePageHistory;


### PR DESCRIPTION
## Summary
- Adds an undo/redo stack for page/header/filter edits (Ctrl+Z / Ctrl+Shift+Z), extracted into `src/utils/usePageHistory.ts`
- Undo/redo is gated behind a new opt-in `historyEnabled` per-device setting, toggled from a checkbox in the Settings page's "Experimental Settings" section
- Reconciles the history stack against sync merges (`pageMerge.ts`) so undo/redo doesn't fight incoming remote changes
- Adds undo/redo icon buttons to the app header, disabled when there's nothing to undo/redo

## Test plan
- [x] `bun test` (settings.test.ts covers toggleHistoryEnabled, undo/redo, and sync reconciliation)
- [x] Manually verified the Settings page checkbox toggles `historyEnabled` and persists via local storage