### PR TITLE
Add one-time header sorting by name, value, or comment

### DIFF
--- a/e2e/header-sort.spec.ts
+++ b/e2e/header-sort.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect } from "./baseTest";
+
+test.describe("Header Sort", () => {
+  test("sorts headers by name ascending", async ({ popupPage }) => {
+    await popupPage.pages.addEmptyPage();
+    await popupPage.headers.addHeader("Zebra", "z-value");
+    await popupPage.headers.addHeader("Apple", "a-value");
+    await popupPage.headers.addHeader("Mango", "m-value");
+
+    await popupPage.headers.sortBy("headerName", "asc");
+
+    await expect(popupPage.headers.getHeaderName(0)).resolves.toBe("Apple");
+    await expect(popupPage.headers.getHeaderName(1)).resolves.toBe("Mango");
+    await expect(popupPage.headers.getHeaderName(2)).resolves.toBe("Zebra");
+  });
+
+  test("sorts headers by name descending", async ({ popupPage }) => {
+    await popupPage.pages.addEmptyPage();
+    await popupPage.headers.addHeader("Zebra", "z-value");
+    await popupPage.headers.addHeader("Apple", "a-value");
+    await popupPage.headers.addHeader("Mango", "m-value");
+
+    await popupPage.headers.sortBy("headerName", "desc");
+
+    await expect(popupPage.headers.getHeaderName(0)).resolves.toBe("Zebra");
+    await expect(popupPage.headers.getHeaderName(1)).resolves.toBe("Mango");
+    await expect(popupPage.headers.getHeaderName(2)).resolves.toBe("Apple");
+  });
+
+  test("sorts headers by value", async ({ popupPage }) => {
+    await popupPage.pages.addEmptyPage();
+    await popupPage.headers.addHeader("H1", "gamma");
+    await popupPage.headers.addHeader("H2", "alpha");
+    await popupPage.headers.addHeader("H3", "beta");
+
+    await popupPage.headers.sortBy("headerValue", "asc");
+
+    await expect(popupPage.headers.getHeaderValue(0)).resolves.toBe("alpha");
+    await expect(popupPage.headers.getHeaderValue(1)).resolves.toBe("beta");
+    await expect(popupPage.headers.getHeaderValue(2)).resolves.toBe("gamma");
+  });
+
+  test("sorts headers by comment", async ({ popupPage }) => {
+    await popupPage.pages.addEmptyPage();
+    await popupPage.headers.showComments();
+
+    await popupPage.headers.addHeader("H1", "v1");
+    await popupPage.headers.setHeaderComment(0, "third");
+    await popupPage.headers.addHeader("H2", "v2");
+    await popupPage.headers.setHeaderComment(1, "first");
+    await popupPage.headers.addHeader("H3", "v3");
+    await popupPage.headers.setHeaderComment(2, "second");
+
+    await popupPage.headers.sortBy("headerComment", "asc");
+
+    await expect(popupPage.headers.getHeaderComment(0)).resolves.toBe("first");
+    await expect(popupPage.headers.getHeaderComment(1)).resolves.toBe("second");
+    await expect(popupPage.headers.getHeaderComment(2)).resolves.toBe("third");
+  });
+
+  test("sort is a one-time operation, not persisted as a setting", async ({ popupPage }) => {
+    await popupPage.pages.addEmptyPage();
+    await popupPage.headers.addHeader("Zebra", "z-value");
+    await popupPage.headers.addHeader("Apple", "a-value");
+
+    await popupPage.headers.sortBy("headerName", "asc");
+    await expect(popupPage.headers.getHeaderName(0)).resolves.toBe("Apple");
+
+    // Adding a new header afterwards should not re-trigger sorting.
+    await popupPage.headers.addHeader("Middle", "mid-value");
+    await expect(popupPage.headers.getHeaderName(2)).resolves.toBe("Middle");
+  });
+});

--- a/e2e/pages/headerSection.ts
+++ b/e2e/pages/headerSection.ts
@@ -3,10 +3,22 @@ import { Locator, Page } from "@playwright/test";
 export class HeaderSection {
   readonly page: Page;
   readonly addButton: Locator;
+  readonly toggleCommentsButton: Locator;
+  readonly sortButton: Locator;
+  readonly sortDropdown: Locator;
+  readonly sortFieldSelect: Locator;
+  readonly sortDirectionSelect: Locator;
+  readonly sortApplyButton: Locator;
 
   constructor(page: Page) {
     this.page = page;
     this.addButton = page.getByTestId("add-header");
+    this.toggleCommentsButton = page.getByTestId("toggle-header-comments");
+    this.sortButton = page.getByTestId("sort-headers-button");
+    this.sortDropdown = page.getByTestId("sort-headers-dropdown");
+    this.sortFieldSelect = page.getByTestId("sort-headers-field");
+    this.sortDirectionSelect = page.getByTestId("sort-headers-direction");
+    this.sortApplyButton = page.getByTestId("sort-headers-apply");
   }
 
   get rows(): Locator {
@@ -61,5 +73,46 @@ export class HeaderSection {
 
   async count(): Promise<number> {
     return this.rows.count();
+  }
+
+  async setHeaderComment(index: number, comment: string): Promise<void> {
+    await this.row(index).getByTestId("header-comment").fill(comment);
+  }
+
+  async getHeaderComment(index: number): Promise<string> {
+    return this.row(index).getByTestId("header-comment").inputValue();
+  }
+
+  async showComments(): Promise<void> {
+    const state = await this.toggleCommentsButton.getAttribute("title");
+    if (state === "Show the header comments") {
+      await this.toggleCommentsButton.click();
+    }
+  }
+
+  /**
+   * Opens the sort popup, selects the given field/direction, and applies it.
+   * The popup closes itself on apply.
+   */
+  async sortBy(
+    field: "headerName" | "headerValue" | "headerComment",
+    direction: "asc" | "desc" = "asc"
+  ): Promise<void> {
+    await this.sortButton.click();
+    await this.sortDropdown.waitFor({ state: "visible" });
+    await this.sortFieldSelect.selectOption(field);
+    await this.sortDirectionSelect.selectOption(direction);
+    await this.sortApplyButton.click();
+    await this.sortDropdown.waitFor({ state: "hidden" });
+  }
+
+  async getAllHeaderNames(): Promise<string[]> {
+    return this.rows.evaluateAll((rows) =>
+      rows.map(
+        (row) =>
+          (row.querySelector('[data-testid="header-name"]') as HTMLInputElement)
+            ?.value ?? ""
+      )
+    );
   }
 }

--- a/src/components/headerRow/index.tsx
+++ b/src/components/headerRow/index.tsx
@@ -214,6 +214,7 @@ const HeaderRow = ({
             value={headerComment}
             onChange={updateComment}
             onFocus={handleFocus}
+            data-testid="header-comment"
           />
         </div>
       )}

--- a/src/components/icons/Sort.tsx
+++ b/src/components/icons/Sort.tsx
@@ -1,0 +1,23 @@
+import type { SVGProps } from "react";
+
+const Sort = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+    {...props}
+  >
+    <path d="M3 7h11" />
+    <path d="M3 12h7" />
+    <path d="M3 17h4" />
+    <path d="M17 4v16" />
+    <path d="M13 16l4 4 4-4" />
+  </svg>
+);
+
+export default Sort;

--- a/src/components/pageTitle/index.tsx
+++ b/src/components/pageTitle/index.tsx
@@ -8,10 +8,12 @@ import {
 } from "../../context/settingsContext";
 import { useAlert } from "../../context/alertContext";
 import CommentToggle from "../icons/CommentToggle";
+import SortHeadersDropdown from "../sortHeadersDropdown";
+import { HeaderSetting } from "../../utils/settings";
 
 const PageTitle = () => {
   const { pages, currentPage } = useSettingsState();
-  const { updatePage, changePageIndex } = useSettingsActions();
+  const { updatePage, changePageIndex, saveHeaders } = useSettingsActions();
   const alertContext = useAlert();
 
   const name = currentPage.name;
@@ -31,6 +33,10 @@ const PageTitle = () => {
       ...currentPage,
       showHeaderComments: !currentPage.showHeaderComments,
     });
+  };
+
+  const onSort = (sortedHeaders: HeaderSetting[]) => {
+    saveHeaders(sortedHeaders, currentPage.id);
   };
 
   const onMoveLeft = () =>
@@ -113,7 +119,9 @@ const PageTitle = () => {
               <CommentToggle className="page-title__toggle-icon" />
             </span>
           }
+          testId="toggle-header-comments"
         />
+        <SortHeadersDropdown headers={currentPage.headers} onSort={onSort} />
         <Button onClick={onMoveLeft} content="<" testId="page-move-left" />
         <Button onClick={onMoveRight} content=">" testId="page-move-right" />
       </div>

--- a/src/components/sortHeadersDropdown/index.css
+++ b/src/components/sortHeadersDropdown/index.css
@@ -1,0 +1,59 @@
+.sort-headers-dropdown {
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 220px;
+  padding: 10px;
+  background-color: var(--background-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-card);
+  font-size: 14px;
+  color: var(--text-color);
+  text-align: left;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(-10px);
+  transition: all 0.2s ease-in-out;
+}
+
+.sort-headers-dropdown.active {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+}
+
+.sort-headers-dropdown__item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.sort-headers-dropdown__item select {
+  width: 100%;
+  padding: 4px;
+  background-color: var(--background-quinary);
+  color: var(--text-color);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm, 4px);
+}
+
+.sort-headers-dropdown__actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.sort-headers-dropdown__toggle-content {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.sort-headers-dropdown__toggle-icon {
+  width: 16px;
+  height: 16px;
+}

--- a/src/components/sortHeadersDropdown/index.tsx
+++ b/src/components/sortHeadersDropdown/index.tsx
@@ -1,0 +1,130 @@
+import { useState, useRef, useEffect } from "react";
+import { HeaderSetting } from "../../utils/settings";
+import Button from "../button";
+import Sort from "../icons/Sort";
+import "./index.css";
+
+type SortField = "headerName" | "headerValue" | "headerComment";
+type SortDirection = "asc" | "desc";
+
+const FIELD_OPTIONS: { value: SortField; label: string }[] = [
+  { value: "headerName", label: "Header Name" },
+  { value: "headerValue", label: "Header Value" },
+  { value: "headerComment", label: "Comment" },
+];
+
+const SortHeadersDropdown = ({
+  headers,
+  onSort,
+}: {
+  headers: HeaderSetting[];
+  onSort: (sortedHeaders: HeaderSetting[]) => void;
+}) => {
+  const [show, setShow] = useState(false);
+  const [field, setField] = useState<SortField>("headerName");
+  const [direction, setDirection] = useState<SortDirection>("asc");
+  const buttonRef = useRef<HTMLDivElement>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const [buttonLocation, setButtonLocation] = useState<DOMRect | undefined>(
+    undefined
+  );
+
+  useEffect(() => {
+    if (buttonRef.current) {
+      setButtonLocation(buttonRef.current.getBoundingClientRect());
+    }
+  }, [buttonRef, show]);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node) &&
+        buttonRef.current &&
+        !buttonRef.current.contains(event.target as Node)
+      ) {
+        setShow(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [dropdownRef]);
+
+  const _handleSort = () => {
+    const sorted = [...headers].sort((a, b) => {
+      const result = a[field].localeCompare(b[field], undefined, {
+        sensitivity: "base",
+      });
+      return direction === "asc" ? result : -result;
+    });
+    onSort(sorted);
+    setShow(false);
+  };
+
+  return (
+    <>
+      <div ref={buttonRef}>
+        <Button
+          onClick={() => setShow(!show)}
+          color="secondary"
+          title="Sort headers"
+          content={
+            <span className="sort-headers-dropdown__toggle-content">
+              <Sort className="sort-headers-dropdown__toggle-icon" />
+            </span>
+          }
+          testId="sort-headers-button"
+        />
+      </div>
+      <div
+        className={`sort-headers-dropdown ${show ? "active" : ""}`}
+        ref={dropdownRef}
+        style={{
+          top: (buttonLocation?.bottom || 0) + 5,
+          right: (window.innerWidth - (buttonLocation?.right || 0)) as number,
+        }}
+        data-testid="sort-headers-dropdown"
+      >
+        <div className="sort-headers-dropdown__item">
+          <label htmlFor="sort-headers-field">Sort by</label>
+          <select
+            id="sort-headers-field"
+            value={field}
+            onChange={(e) => setField(e.target.value as SortField)}
+            data-testid="sort-headers-field"
+          >
+            {FIELD_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="sort-headers-dropdown__item">
+          <label htmlFor="sort-headers-direction">Order</label>
+          <select
+            id="sort-headers-direction"
+            value={direction}
+            onChange={(e) => setDirection(e.target.value as SortDirection)}
+            data-testid="sort-headers-direction"
+          >
+            <option value="asc">Ascending (A-Z)</option>
+            <option value="desc">Descending (Z-A)</option>
+          </select>
+        </div>
+        <div className="sort-headers-dropdown__actions">
+          <Button
+            onClick={_handleSort}
+            width="full"
+            content="Sort"
+            testId="sort-headers-apply"
+          />
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default SortHeadersDropdown;


### PR DESCRIPTION
## Summary
- Adds a Sort button next to the comment-toggle in the page title bar that opens a popup for choosing a field (Header Name / Header Value / Comment) and direction (ascending/descending)
- Sorting is a one-time, in-place reorder via the existing `saveHeaders` action - no new setting is persisted
- Adds `header-comment` and `toggle-header-comments` test ids to support e2e coverage

## Test plan
- [x] `bun run tsc --noEmit` passes
- [x] Manually verified in the web-dev popup preview: added Zebra/Apple/Mango headers, sorted ascending, confirmed Apple/Mango/Zebra order
- [x] Added `e2e/header-sort.spec.ts` covering sort by name (asc/desc), by value, by comment, and confirming sort doesn't get re-applied on later edits
- [x] Full `playwright test` suite passes (35/35)