### PR TITLE
Clarify page context menu wording, fix stale toggle state

### DIFF
--- a/src/components/pageContextMenu/index.tsx
+++ b/src/components/pageContextMenu/index.tsx
@@ -96,13 +96,13 @@ export const PageContextMenu = ({
           onClick={handleToggle}
           aria-label={
             page.keepEnabled
-              ? "Disable background running"
-              : "Enable background running"
+              ? "Only apply headers when this page is selected"
+              : "Always apply headers, even when this page is not selected"
           }
           data-testid="page-context-toggle-background"
         >
           <Power className="page-context-menu__icon" />
-          Run in background
+          Always apply
         </button>
       </div>
       <div className="page-context-menu__item">

--- a/src/components/pagesList/index.tsx
+++ b/src/components/pagesList/index.tsx
@@ -14,10 +14,11 @@ export const PagesList = () => {
   const { addPage, changeSelectedPage } = useSettingsActions();
   const [collapsed, setCollapsed] = useState(false);
   const [contextMenu, setContextMenu] = useState<{
-    page: Page;
+    pageId: number;
     x: number;
     y: number;
   } | null>(null);
+  const contextMenuPage = pages.find((page) => page.id === contextMenu?.pageId);
 
   const handleAddPage = () => {
     addPage({
@@ -82,12 +83,12 @@ export const PagesList = () => {
           onClick={changeSelectedPage}
           onContextMenu={(event) => {
             event.preventDefault();
-            setContextMenu({ page, x: event.clientX, y: event.clientY });
+            setContextMenu({ pageId: page.id, x: event.clientX, y: event.clientY });
           }}
         />
       ))}
       <PageContextMenu
-        page={contextMenu?.page}
+        page={contextMenuPage}
         visible={!!contextMenu}
         x={contextMenu?.x ?? 0}
         y={contextMenu?.y ?? 0}


### PR DESCRIPTION
## Summary
- Replaced the confusing "Run in background" label on the page context menu with "Always apply", plus aria-labels that spell out what the toggle does (headers apply even when the page isn't selected).
- Fixed a stale-state bug: the context menu stored a snapshot of the `Page` object at right-click time, so the toggle's own displayed state didn't update while the menu stayed open. It now derives the current page live from the `pages` array by id on every render.
- No storage schema or field-name changes — `page.keepEnabled` is untouched, so this is fully backward/forward compatible with synced data from older versions.

## Test plan
- [x] Manually verified in the browser (WXT dev-web build, popup mode): right-click a page, toggle without closing the menu, confirm the label updates live.