### PR TITLE
Support importing ModHeader exports

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,21 @@ changed" rot the moment the PR merges.
   owning all page/header/filter state and its persistence. Exposed via
   `src/context/settingsContext.tsx` to the popup/options UI.
 - `src/background/rules.ts` — turns pages/headers/filters into
-  `declarativeNetRequest` rules (`buildRulesFromPages`).
+  `declarativeNetRequest` rules (`buildRulesFromPages`). A filter only
+  contributes to rule generation when `filter.valid === true`
+  (`buildHeaderRules`); the UI normally sets this via
+  `src/utils/domain/filterValidation.ts`'s `filterIsValid` (which calls
+  `browser.declarativeNetRequest.isRegexSupported` for regex mode). Any code
+  that constructs `HeaderFilter`s outside that flow - e.g. an importer
+  converting a third-party format - must run them through `filterIsValid`
+  too, or the filter silently no-ops instead of erroring.
+- `src/utils/io/modHeaderImport.ts` — converts a ModHeader JSON export
+  (plain array of profile objects, no wrapper) into FlexHeader pages;
+  `src/utils/io/importSettings.ts` tries the native FlexHeader schema first
+  and falls back to this. The conversion is lossy (no append-mode headers,
+  no HTTP-method filters, no field-level exclude precedence) so converted
+  pages import with `enabled: false` pending review; `alwaysOn` maps to
+  `keepEnabled` since both mean "stay active regardless of page selection".
 - `src/utils/pageStorage.ts` — `readPageStorage(area)`, the one place that
   knows how to read the v3 distributed page format (`settings_v3_meta` +
   `page_N` keys + tombstones) out of a storage area. Used by both

--- a/e2e/export-import.spec.ts
+++ b/e2e/export-import.spec.ts
@@ -1,6 +1,9 @@
+import * as path from "path";
 import { test, expect } from "./baseTest";
 import { Page as FlexHeaderPage } from "../src/utils/settings";
 import { clearExtensionStorage, gotoPopup } from "./fixtures/extension";
+
+const MODHEADER_FIXTURE = path.join(__dirname, "fixtures", "modheader-export.json");
 
 const buildSamplePage = (overrides: Partial<FlexHeaderPage> = {}): FlexHeaderPage => ({
   id: 0,
@@ -134,6 +137,34 @@ test.describe("Export / Import", () => {
     await expect(popupPage.headers.getHeaderValue(0)).resolves.toBe("trip-value");
     await expect(popupPage.headers.getHeaderType(0)).resolves.toBe("response");
     await expect(popupPage.filters.getFilterMode(0)).resolves.toBe("regex");
+  });
+
+  test("imports a ModHeader export, converting it to a FlexHeader page", async ({ popupPage }) => {
+    await popupPage.exportImport.openImportPopup();
+    await popupPage.exportImport.importFixture(MODHEADER_FIXTURE);
+
+    await expect(
+      popupPage.page.locator(".drag-drop-file__status--success")
+    ).toBeVisible();
+
+    await expect(popupPage.pages.listItem("Testing Env")).toBeVisible();
+    await popupPage.pages.selectPage("Testing Env");
+
+    // alwaysOn -> keepEnabled, so the page shows as active without being
+    // individually enabled/selected as "the" page.
+    await expect(popupPage.headers.rows).toHaveCount(4);
+    await expect(popupPage.headers.getHeaderName(0)).resolves.toBe("test");
+    await expect(popupPage.headers.getHeaderValue(0)).resolves.toBe("asdf");
+    await expect(popupPage.headers.isHeaderEnabled(0)).resolves.toBe(true);
+    await expect(popupPage.headers.isHeaderEnabled(1)).resolves.toBe(false);
+
+    await expect(popupPage.filters.rows).toHaveCount(2);
+    await expect(popupPage.filters.getFilterType(0)).resolves.toBe("include");
+    await expect(popupPage.filters.getFilterMode(0)).resolves.toBe("regex");
+    await expect(popupPage.filters.getFilterValue(0)).resolves.toBe(
+      ".*://localhost:8080/.*"
+    );
+    await expect(popupPage.filters.isFilterValid(0)).resolves.toBe(true);
   });
 
   test("shows an error when importing an invalid JSON file", async ({ popupPage }) => {

--- a/e2e/fixtures/modheader-export.json
+++ b/e2e/fixtures/modheader-export.json
@@ -1,0 +1,45 @@
+[
+    {
+        "alwaysOn": true,
+        "headers": [
+            {
+                "appendMode": false,
+                "enabled": true,
+                "name": "test",
+                "value": "asdf",
+                "comment": "Testing 2"
+            },
+            {
+                "appendMode": false,
+                "enabled": false,
+                "name": "test",
+                "value": "abcd"
+            },
+            {
+                "enabled": false,
+                "name": "test",
+                "value": "abc",
+                "comment": "Testing"
+            },
+            {
+                "enabled": false,
+                "name": "test",
+                "value": "qwerty"
+            }
+        ],
+        "shortTitle": "G",
+        "title": "Testing Env",
+        "urlFilters": [
+            {
+                "enabled": false,
+                "urlRegex": ".*://localhost:8080/.*"
+            },
+            {
+                "enabled": false,
+                "urlRegex": ".*://localhost:8000/.*"
+            }
+        ],
+        "version": 2,
+        "hideComment": false
+    }
+]

--- a/e2e/pages/exportImportSection.ts
+++ b/e2e/pages/exportImportSection.ts
@@ -101,4 +101,12 @@ export class ExportImportSection {
     fs.writeFileSync(tmpFile, JSON.stringify(content), "utf-8");
     await this.importFileInput.setInputFiles(tmpFile);
   }
+
+  /**
+   * Imports a fixture file directly (e.g. a ModHeader export), without
+   * round-tripping it through FlexHeader's own Page type.
+   */
+  async importFixture(fixturePath: string): Promise<void> {
+    await this.importFileInput.setInputFiles(fixturePath);
+  }
 }

--- a/e2e/pages/pageSection.ts
+++ b/e2e/pages/pageSection.ts
@@ -32,7 +32,7 @@ export class PageSection {
   }
 
   async getActivePageName(): Promise<string> {
-    return this.page.locator(".page-list-item.active h3").textContent();
+    return (await this.page.locator(".page-list-item.active h3").textContent()) ?? "";
   }
 
   async addNewPage(): Promise<void> {

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "ignoreDeprecations": "6.0",
     "target": "es2020",
     "module": "esnext",
     "moduleResolution": "node",

--- a/src/background/background.test.ts
+++ b/src/background/background.test.ts
@@ -475,7 +475,6 @@ describe('buildRulesFromPages migration regression', () => {
       enabled: true,
       keepEnabled: false,
       showHeaderComments: true,
-      filtersExpanded: true,
       filters: [
         {
           id: 'filter-1',
@@ -517,7 +516,6 @@ describe('buildRulesFromPages migration regression', () => {
       enabled: true,
       keepEnabled: false,
       showHeaderComments: true,
-      filtersExpanded: true,
       filters: [],
       headers: [
         {
@@ -544,7 +542,6 @@ describe('buildRulesFromPages migration regression', () => {
       enabled: false,
       keepEnabled: false,
       showHeaderComments: true,
-      filtersExpanded: true,
       filters: [],
       headers: [
         {

--- a/src/background/backgroundSync.test.ts
+++ b/src/background/backgroundSync.test.ts
@@ -81,7 +81,6 @@ const createPage = (
   enabled: id === 0,
   keepEnabled: false,
   showHeaderComments: true,
-  filtersExpanded: true,
   filters: [],
   ...identity,
   headers: [

--- a/src/components/dragDropFile/index.css
+++ b/src/components/dragDropFile/index.css
@@ -115,6 +115,10 @@
   filter: brightness(0) saturate(100%) invert(48%) sepia(79%) saturate(2476%) hue-rotate(86deg) brightness(118%) contrast(119%);
 }
 
+.drag-drop-file__status--warning img {
+  filter: brightness(0) saturate(100%) invert(75%) sepia(60%) saturate(1000%) hue-rotate(0deg) brightness(103%) contrast(101%);
+}
+
 .drag-drop-file__status--error img {
   filter: brightness(0) saturate(100%) invert(32%) sepia(90%) saturate(7450%) hue-rotate(348deg) brightness(93%) contrast(101%);
 }

--- a/src/components/dragDropFile/index.css
+++ b/src/components/dragDropFile/index.css
@@ -12,6 +12,7 @@
 }
 
 .drag-drop-file__title,
+.drag-drop-file__hint,
 .drag-drop-file__subtitle {
   display: none;
 }
@@ -76,6 +77,7 @@
 }
 
 .drag-drop-file--large .drag-drop-file__title,
+.drag-drop-file--large .drag-drop-file__hint,
 .drag-drop-file--large .drag-drop-file__subtitle {
   display: block;
 }
@@ -83,6 +85,11 @@
 .drag-drop-file--large .drag-drop-file__title {
   font-size: 1rem;
   font-weight: 600;
+}
+
+.drag-drop-file--large .drag-drop-file__hint {
+  font-size: 0.8rem;
+  opacity: 0.6;
 }
 
 .drag-drop-file--large .drag-drop-file__subtitle {

--- a/src/components/dragDropFile/index.tsx
+++ b/src/components/dragDropFile/index.tsx
@@ -3,9 +3,10 @@ import "./index.css";
 import Import from "../icons/Import";
 import Check from "../icons/Check";
 import ErrorIcon from "../icons/ErrorIcon";
+import WarningIcon from "../icons/Warning";
 
 interface DragDropFileProps {
-  importSettings: (file: File) => Promise<void>;
+  importSettings: (file: File) => Promise<{ warnings: string[] }>;
   closeCallback?: () => void;
   variant?: "compact" | "large";
 }
@@ -19,16 +20,25 @@ const DragDropFile = ({
   const inputRef = useRef<HTMLInputElement>(null);
   const [isDragging, setIsDragging] = useState(false);
   const [status, setStatus] = useState<
-    { type: "success"; message: string } | { type: "error"; message: string } | null
+    | { type: "success"; message: string }
+    | { type: "warning"; message: string }
+    | { type: "error"; message: string }
+    | null
   >(null);
 
   const runImport = async (file: File) => {
     setStatus(null);
 
     try {
-      await importSettings(file);
-      setStatus({ type: "success", message: "Import successful" });
-      closeCallback?.();
+      const { warnings } = await importSettings(file);
+      if (warnings.length > 0) {
+        // Keep the popup open so the warnings are actually seen, rather than
+        // closing immediately the way a clean import does.
+        setStatus({ type: "warning", message: warnings.join(" ") });
+      } else {
+        setStatus({ type: "success", message: "Import successful" });
+        closeCallback?.();
+      }
     } catch (error) {
       const message = error instanceof Error ? error.message : "Import failed";
       setStatus({ type: "error", message });
@@ -116,16 +126,16 @@ const DragDropFile = ({
 
       {status && (
         <div
-          className={`drag-drop-file__status ${
-            status.type === "success"
-              ? "drag-drop-file__status--success"
-              : "drag-drop-file__status--error"
-          }`}
+          className={`drag-drop-file__status drag-drop-file__status--${status.type}`}
           data-testid="drag-drop-file-status"
         >
-          {status.type === "success" ? (
+          {status.type === "success" && (
             <Check role="img" aria-label="Import successful" width={16} height={16} />
-          ) : (
+          )}
+          {status.type === "warning" && (
+            <WarningIcon role="img" aria-label="Import completed with warnings" width={16} height={16} />
+          )}
+          {status.type === "error" && (
             <ErrorIcon role="img" aria-label="Import failed" width={16} height={16} />
           )}
           <span>{status.message}</span>

--- a/src/components/dragDropFile/index.tsx
+++ b/src/components/dragDropFile/index.tsx
@@ -103,6 +103,9 @@ const DragDropFile = ({
             <p className="drag-drop-file__title">
               Drag & drop your exported .json file here
             </p>
+            <p className="drag-drop-file__hint">
+              Accepts a FlexHeader export or a ModHeader export
+            </p>
             <p className="drag-drop-file__subtitle">or</p>
             <button type="button" className="upload-button" onClick={onButtonClick} data-testid="drag-drop-file-upload-button">
               Click to upload a file

--- a/src/components/importPopup/index.tsx
+++ b/src/components/importPopup/index.tsx
@@ -6,7 +6,7 @@ import DragDropFile from "../dragDropFile";
 import Import from "../icons/Import";
 
 interface ImportPopupProps {
-  importSettings: (file: File) => Promise<void>;
+  importSettings: (file: File) => Promise<{ warnings: string[] }>;
 }
 
 const ImportPopup = ({ importSettings }: ImportPopupProps) => {

--- a/src/components/pagesList/index.tsx
+++ b/src/components/pagesList/index.tsx
@@ -25,7 +25,6 @@ export const PagesList = () => {
       enabled: true,
       keepEnabled: false,
       showHeaderComments: true,
-      filtersExpanded: true,
       name: "New Page",
       headers: [],
       filters: [],

--- a/src/context/settingsContext.tsx
+++ b/src/context/settingsContext.tsx
@@ -50,7 +50,7 @@ type SettingsActionsContextValue = {
   changeSelectedPage: (id: number) => void;
   changePageIndex: (oldIndex: number, newIndex: number) => void;
 
-  importSettings: (file: File) => Promise<void>;
+  importSettings: (file: File) => Promise<{ warnings: string[] }>;
   toggleDarkMode: () => Promise<void>;
   toggleSync: () => Promise<void>;
   clearErrors: (category?: AppError["category"]) => Promise<void>;

--- a/src/utils/domain/headers.test.ts
+++ b/src/utils/domain/headers.test.ts
@@ -16,7 +16,6 @@ const createPage = (id: number, name: string, enabled: boolean, headers: HeaderS
   enabled,
   keepEnabled: false,
   showHeaderComments: true,
-  filtersExpanded: true,
   headers,
   filters: [],
 });
@@ -104,20 +103,6 @@ describe('normalizePage', () => {
 
     expect(normalized.filters[0].mode).toBe('regex');
     expect(normalized.headers[0].headerType).toBe('request');
-  });
-
-  it('defaults a missing filtersExpanded to true', () => {
-    const page = {
-      id: 0,
-      name: 'Default',
-      enabled: true,
-      keepEnabled: false,
-      showHeaderComments: true,
-      filters: [],
-      headers: [],
-    };
-
-    expect(normalizePage(page).filtersExpanded).toBe(true);
   });
 });
 

--- a/src/utils/domain/headers.ts
+++ b/src/utils/domain/headers.ts
@@ -33,7 +33,6 @@ export const normalizePage = (page: any): Page => ({
   ...page,
   lastModified: page.lastModified ?? 0,
   showHeaderComments: page.showHeaderComments ?? true,
-  filtersExpanded: page.filtersExpanded ?? true,
   headers: page.headers?.map(normalizeHeader) || [],
   filters: page.filters?.map(normalizeFilter) || [],
 });

--- a/src/utils/domain/pageMerge.test.ts
+++ b/src/utils/domain/pageMerge.test.ts
@@ -53,7 +53,6 @@ const createPage = (
   enabled,
   keepEnabled: false,
   showHeaderComments: true,
-  filtersExpanded: true,
   headers,
   filters,
 });

--- a/src/utils/domain/schemas.ts
+++ b/src/utils/domain/schemas.ts
@@ -32,7 +32,6 @@ export const pageSchema = z.object({
   enabled: z.boolean(),
   keepEnabled: z.boolean(),
   showHeaderComments: z.boolean().default(true),
-  filtersExpanded: z.boolean().default(true),
   filters: z.array(headerFilterSchema).default([]),
   headers: z.array(headerSettingSchema).default([]),
   // Resolves which side wins when the same page is edited on two synced

--- a/src/utils/hooks/useSyncToggle.test.ts
+++ b/src/utils/hooks/useSyncToggle.test.ts
@@ -44,7 +44,6 @@ const makePage = (overrides: Partial<Page> = {}): Page => ({
   enabled: true,
   keepEnabled: false,
   showHeaderComments: true,
-  filtersExpanded: true,
   filters: [],
   headers: [],
   lastModified: 100,

--- a/src/utils/io/importSettings.test.ts
+++ b/src/utils/io/importSettings.test.ts
@@ -1,4 +1,16 @@
 import { vi } from 'vitest';
+
+const browserMock = vi.hoisted(() => ({
+  declarativeNetRequest: {
+    isRegexSupported: vi.fn().mockResolvedValue({ isSupported: true }),
+  },
+}));
+
+vi.mock('webextension-polyfill', () => ({
+  default: browserMock,
+  ...browserMock,
+}));
+
 import type { Dispatch, SetStateAction } from 'react';
 import { importSettingsFile } from './importSettings';
 import type { Page, PagesData } from '../domain/schemas';
@@ -16,7 +28,6 @@ const createPage = (id: number, name: string, enabled: boolean, pageId?: string)
   enabled,
   keepEnabled: false,
   showHeaderComments: true,
-  filtersExpanded: true,
   headers: [],
   filters: [],
 });
@@ -63,5 +74,50 @@ describe('importSettingsFile', () => {
     await expect(importSettingsFile(file, { setPagesData, alertContext })).rejects.toThrow();
     expect(setPagesData).not.toHaveBeenCalled();
     expect(alertContext.setAlert).toHaveBeenCalledWith(expect.objectContaining({ alertType: 'error' }));
+  });
+
+  it('converts a ModHeader export into pages, imported disabled with a warning alert', async () => {
+    let pagesData: PagesData = { pages: [], selectedPage: 0 };
+    const setPagesData: Dispatch<SetStateAction<PagesData>> = vi.fn((updater) => {
+      pagesData = typeof updater === 'function' ? updater(pagesData) : updater;
+    });
+    const alertContext = createAlertContext();
+
+    const modHeaderExport = [
+      {
+        alwaysOn: false,
+        title: 'Testing Env',
+        headers: [{ appendMode: true, enabled: true, name: 'test', value: 'asdf', comment: 'Testing 2' }],
+        urlFilters: [{ enabled: true, urlRegex: '.*://localhost:8080/.*' }],
+        version: 2,
+        hideComment: false,
+      },
+    ];
+    const file = new File([JSON.stringify(modHeaderExport)], 'modheader-export.json', { type: 'application/json' });
+
+    await importSettingsFile(file, { setPagesData, alertContext });
+
+    expect(pagesData.pages).toHaveLength(1);
+    expect(pagesData.pages[0]).toMatchObject({
+      name: 'Testing Env',
+      enabled: false,
+      headers: [expect.objectContaining({ headerName: 'test', headerValue: 'asdf' })],
+      filters: [expect.objectContaining({ type: 'include', mode: 'regex', valid: true })],
+    });
+    expect(pagesData.pages[0].pageId).toBeTruthy();
+    expect(alertContext.setAlert).toHaveBeenCalledWith(
+      expect.objectContaining({ alertType: 'warning', alertText: expect.stringContaining('append mode') })
+    );
+  });
+
+  it('rejects a file that matches neither FlexHeader nor ModHeader shape', async () => {
+    const setPagesData = vi.fn();
+    const alertContext = createAlertContext();
+    const file = new File([JSON.stringify([{ foo: 'bar' }])], 'export.json', { type: 'application/json' });
+
+    await expect(importSettingsFile(file, { setPagesData, alertContext })).rejects.toThrow(
+      /FlexHeader or ModHeader/
+    );
+    expect(setPagesData).not.toHaveBeenCalled();
   });
 });

--- a/src/utils/io/importSettings.test.ts
+++ b/src/utils/io/importSettings.test.ts
@@ -76,7 +76,7 @@ describe('importSettingsFile', () => {
     expect(alertContext.setAlert).toHaveBeenCalledWith(expect.objectContaining({ alertType: 'error' }));
   });
 
-  it('converts a ModHeader export into pages, imported disabled with a warning alert', async () => {
+  it('converts a ModHeader export into pages, imported disabled with warnings returned (not alerted)', async () => {
     let pagesData: PagesData = { pages: [], selectedPage: 0 };
     const setPagesData: Dispatch<SetStateAction<PagesData>> = vi.fn((updater) => {
       pagesData = typeof updater === 'function' ? updater(pagesData) : updater;
@@ -95,7 +95,7 @@ describe('importSettingsFile', () => {
     ];
     const file = new File([JSON.stringify(modHeaderExport)], 'modheader-export.json', { type: 'application/json' });
 
-    await importSettingsFile(file, { setPagesData, alertContext });
+    const { warnings } = await importSettingsFile(file, { setPagesData, alertContext });
 
     expect(pagesData.pages).toHaveLength(1);
     expect(pagesData.pages[0]).toMatchObject({
@@ -105,9 +105,8 @@ describe('importSettingsFile', () => {
       filters: [expect.objectContaining({ type: 'include', mode: 'regex', valid: true })],
     });
     expect(pagesData.pages[0].pageId).toBeTruthy();
-    expect(alertContext.setAlert).toHaveBeenCalledWith(
-      expect.objectContaining({ alertType: 'warning', alertText: expect.stringContaining('append mode') })
-    );
+    expect(warnings).toEqual([expect.stringContaining('append mode')]);
+    expect(alertContext.setAlert).not.toHaveBeenCalled();
   });
 
   it('rejects a file that matches neither FlexHeader nor ModHeader shape', async () => {

--- a/src/utils/io/importSettings.ts
+++ b/src/utils/io/importSettings.ts
@@ -1,12 +1,40 @@
 import { z } from "zod";
 import type { Dispatch, SetStateAction } from "react";
 import type { AlertContextType } from "../../context/alertContext";
-import { pageSchema, type PagesData } from "../domain/schemas";
+import { pageSchema, type Page, type PagesData } from "../domain/schemas";
 import { normalizePage } from "../domain/headers";
+import { convertModHeaderProfile, isModHeaderExport } from "./modHeaderImport";
 
 const importedPayloadSchema = z
   .array(pageSchema)
   .min(1, "Imported file does not contain any pages.");
+
+const INVALID_FILE_MESSAGE =
+  "Invalid settings file. Please export settings from FlexHeader or ModHeader and try again.";
+
+/**
+ * Accepts either a FlexHeader settings export or a ModHeader profile export.
+ * FlexHeader's own schema is tried first; a file that doesn't match it falls
+ * back to ModHeader detection rather than failing outright.
+ */
+const parseImportedPages = async (
+  parsedJson: unknown
+): Promise<{ pages: Page[]; warnings: string[] }> => {
+  const flexHeaderResult = importedPayloadSchema.safeParse(parsedJson);
+  if (flexHeaderResult.success) {
+    return { pages: flexHeaderResult.data.map(normalizePage), warnings: [] };
+  }
+
+  if (isModHeaderExport(parsedJson)) {
+    const warnings = new Set<string>();
+    const pages = await Promise.all(
+      parsedJson.map((profile, index) => convertModHeaderProfile(profile, index, warnings))
+    );
+    return { pages, warnings: [...warnings] };
+  }
+
+  throw new Error(INVALID_FILE_MESSAGE);
+};
 
 /**
  * Parses an exported settings JSON file and appends its pages to the
@@ -28,7 +56,7 @@ export const importSettingsFile = (
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
     reader.onerror = () => reject(new Error("Failed to read file."));
-    reader.onload = (e) => {
+    reader.onload = async (e) => {
       try {
         const result = e.target?.result;
 
@@ -37,11 +65,11 @@ export const importSettingsFile = (
           return;
         }
 
-        const parsed = importedPayloadSchema.parse(JSON.parse(result));
+        const { pages: parsedPages, warnings } = await parseImportedPages(JSON.parse(result));
 
         // remap the ids to avoid conflicts
         setPagesData((prev) => {
-          const importedPages = parsed.map(normalizePage).map((page) => ({
+          const importedPages = parsedPages.map((page) => ({
             ...page,
             pageId: crypto.randomUUID(),
             lastModified: page.lastModified || Date.now(),
@@ -58,22 +86,23 @@ export const importSettingsFile = (
           };
         });
 
-        alertContext.setAlert({
-          alertType: "success",
-          alertText: "Settings imported.",
-          location: "bottom",
-        });
+        alertContext.setAlert(
+          warnings.length > 0
+            ? {
+                alertType: "warning",
+                alertText: `Imported from ModHeader with some limitations: ${warnings.join(" ")}`,
+                location: "bottom",
+              }
+            : {
+                alertType: "success",
+                alertText: "Settings imported.",
+                location: "bottom",
+              }
+        );
 
         resolve();
       } catch (error) {
-        const err =
-          error instanceof z.ZodError
-            ? new Error(
-                "Invalid settings file. Please export settings from FlexHeaders and try again."
-              )
-            : error instanceof Error
-              ? error
-              : new Error("Failed to import settings.");
+        const err = error instanceof Error ? error : new Error("Failed to import settings.");
 
         alertContext.setAlert({
           alertType: "error",

--- a/src/utils/io/importSettings.ts
+++ b/src/utils/io/importSettings.ts
@@ -52,7 +52,7 @@ export const importSettingsFile = (
     setPagesData: Dispatch<SetStateAction<PagesData>>;
     alertContext: AlertContextType;
   }
-): Promise<void> => {
+): Promise<{ warnings: string[] }> => {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
     reader.onerror = () => reject(new Error("Failed to read file."));
@@ -86,21 +86,15 @@ export const importSettingsFile = (
           };
         });
 
-        alertContext.setAlert(
-          warnings.length > 0
-            ? {
-                alertType: "warning",
-                alertText: `Imported from ModHeader with some limitations: ${warnings.join(" ")}`,
-                location: "bottom",
-              }
-            : {
-                alertType: "success",
-                alertText: "Settings imported.",
-                location: "bottom",
-              }
-        );
+        if (warnings.length === 0) {
+          alertContext.setAlert({
+            alertType: "success",
+            alertText: "Settings imported.",
+            location: "bottom",
+          });
+        }
 
-        resolve();
+        resolve({ warnings });
       } catch (error) {
         const err = error instanceof Error ? error : new Error("Failed to import settings.");
 

--- a/src/utils/io/modHeaderImport.test.ts
+++ b/src/utils/io/modHeaderImport.test.ts
@@ -1,0 +1,150 @@
+import { vi } from 'vitest';
+
+const browserMock = vi.hoisted(() => ({
+  declarativeNetRequest: {
+    isRegexSupported: vi.fn(async ({ regex }: { regex: string }) => {
+      try {
+        new RegExp(regex);
+        return { isSupported: true };
+      } catch {
+        return { isSupported: false, reason: 'SYNTAX_ERROR' };
+      }
+    }),
+  },
+}));
+
+vi.mock('webextension-polyfill', () => ({
+  default: browserMock,
+  ...browserMock,
+}));
+
+import { convertModHeaderProfile, isModHeaderExport } from './modHeaderImport';
+
+const sampleModHeaderExport = [
+  {
+    alwaysOn: true,
+    headers: [
+      { appendMode: false, enabled: true, name: 'test', value: 'asdf', comment: 'Testing 2' },
+      { appendMode: false, enabled: false, name: 'test', value: 'abcd' },
+      { enabled: false, name: 'test', value: 'abc', comment: 'Testing' },
+      { enabled: false, name: 'test', value: 'qwerty' },
+    ],
+    shortTitle: 'G',
+    title: 'Testing Env',
+    urlFilters: [
+      { enabled: false, urlRegex: '.*://localhost:8080/.*' },
+      { enabled: false, urlRegex: '.*://localhost:8000/.*' },
+    ],
+    version: 2,
+    hideComment: false,
+  },
+];
+
+describe('isModHeaderExport', () => {
+  it('recognizes a ModHeader profile array', () => {
+    expect(isModHeaderExport(sampleModHeaderExport)).toBe(true);
+  });
+
+  it('rejects a FlexHeader page export', () => {
+    const flexHeaderExport = [
+      {
+        id: 0,
+        name: 'Page',
+        enabled: true,
+        keepEnabled: false,
+        showHeaderComments: true,
+        headers: [],
+        filters: [],
+      },
+    ];
+    expect(isModHeaderExport(flexHeaderExport)).toBe(false);
+  });
+
+  it('rejects non-arrays and empty arrays', () => {
+    expect(isModHeaderExport({})).toBe(false);
+    expect(isModHeaderExport([])).toBe(false);
+  });
+});
+
+describe('convertModHeaderProfile', () => {
+  it('converts a ModHeader profile into an equivalent FlexHeader page', async () => {
+    const warnings = new Set<string>();
+    const page = await convertModHeaderProfile(sampleModHeaderExport[0], 0, warnings);
+
+    expect(page.name).toBe('Testing Env');
+    expect(page.keepEnabled).toBe(true); // alwaysOn -> keepEnabled
+    expect(page.enabled).toBe(false); // imported disabled pending review
+    expect(page.showHeaderComments).toBe(true); // !hideComment
+
+    expect(page.headers).toHaveLength(4);
+    expect(page.headers[0]).toMatchObject({
+      headerName: 'test',
+      headerValue: 'asdf',
+      headerComment: 'Testing 2',
+      headerEnabled: true,
+      headerType: 'request',
+    });
+    expect(page.headers[1].headerEnabled).toBe(false);
+
+    expect(page.filters).toHaveLength(2);
+    expect(page.filters[0]).toMatchObject({
+      type: 'include',
+      mode: 'regex',
+      enabled: false,
+      value: '.*://localhost:8080/.*',
+      valid: true,
+    });
+
+    expect(warnings.size).toBe(0);
+  });
+
+  it('maps response headers, exclude filters, and warns on lossy features', async () => {
+    const warnings = new Set<string>();
+    const profile = {
+      title: 'Lossy',
+      headers: [{ name: 'X-Req', value: '1', appendMode: true, enabled: true }],
+      respHeaders: [{ name: 'X-Resp', value: '2', enabled: true }],
+      urlFilters: [{ enabled: true, urlRegex: '.*a.*', methods: ['GET'] }],
+      excludeUrlFilters: [{ enabled: true, urlRegex: '.*b.*' }],
+    };
+
+    const page = await convertModHeaderProfile(profile, 1, warnings);
+
+    expect(page.headers).toHaveLength(2);
+    expect(page.headers.find((h) => h.headerType === 'response')).toMatchObject({
+      headerName: 'X-Resp',
+      headerValue: '2',
+    });
+    expect(page.filters).toHaveLength(2);
+    expect(page.filters.find((f) => f.type === 'exclude')).toMatchObject({
+      value: '.*b.*',
+      valid: true,
+    });
+
+    expect([...warnings].join(' ')).toMatch(/append mode/i);
+    expect([...warnings].join(' ')).toMatch(/method filters/i);
+  });
+
+  it('marks filters with unsupported regex as invalid and warns', async () => {
+    browserMock.declarativeNetRequest.isRegexSupported.mockResolvedValueOnce({
+      isSupported: false,
+      reason: 'SYNTAX_ERROR',
+    });
+    const warnings = new Set<string>();
+    const profile = {
+      title: 'Bad regex',
+      headers: [{ name: 'X', value: '1', enabled: true }],
+      urlFilters: [{ enabled: true, urlRegex: '(unterminated' }],
+    };
+
+    const page = await convertModHeaderProfile(profile, 0, warnings);
+
+    expect(page.filters[0].valid).toBe(false);
+    expect([...warnings].some((w) => /regex Chrome doesn't support/.test(w))).toBe(true);
+  });
+
+  it('falls back to a generated name when title and shortTitle are missing', async () => {
+    const page = await convertModHeaderProfile({ headers: [] }, 2, new Set());
+    expect(page.name).toBe('Imported profile 3');
+  });
+});

--- a/src/utils/io/modHeaderImport.test.ts
+++ b/src/utils/io/modHeaderImport.test.ts
@@ -64,6 +64,16 @@ describe('isModHeaderExport', () => {
     expect(isModHeaderExport({})).toBe(false);
     expect(isModHeaderExport([])).toBe(false);
   });
+
+  it('recognizes a profile with only URL filters configured, no headers yet', () => {
+    const filtersOnlyProfile = [
+      {
+        title: 'Filters only',
+        urlFilters: [{ enabled: true, urlRegex: '.*example\\.com.*' }],
+      },
+    ];
+    expect(isModHeaderExport(filtersOnlyProfile)).toBe(true);
+  });
 });
 
 describe('convertModHeaderProfile', () => {

--- a/src/utils/io/modHeaderImport.ts
+++ b/src/utils/io/modHeaderImport.ts
@@ -32,7 +32,9 @@ interface ModHeaderProfile {
  * version marker at the array level). Distinguished from a FlexHeader export
  * by the absence of `showHeaderComments` - a field every FlexHeader page has
  * carried since before this importer existed - combined with the presence of
- * a ModHeader-shaped header list.
+ * a ModHeader-shaped header/filter list. `urlFilters`/`filters`/
+ * `excludeUrlFilters` are checked too, not just `headers`/`respHeaders`, so a
+ * profile that only has filters configured (no headers yet) still counts.
  */
 export const isModHeaderExport = (data: unknown): data is ModHeaderProfile[] =>
   Array.isArray(data) &&
@@ -41,7 +43,13 @@ export const isModHeaderExport = (data: unknown): data is ModHeaderProfile[] =>
     if (typeof item !== "object" || item === null) return false;
     const p = item as Record<string, unknown>;
     if ("showHeaderComments" in p) return false;
-    return Array.isArray(p.headers) || Array.isArray(p.respHeaders);
+    return (
+      Array.isArray(p.headers) ||
+      Array.isArray(p.respHeaders) ||
+      Array.isArray(p.urlFilters) ||
+      Array.isArray(p.filters) ||
+      Array.isArray(p.excludeUrlFilters)
+    );
   });
 
 const convertHeaders = (
@@ -137,7 +145,7 @@ export const convertModHeaderProfile = async (
 
   if (filters.some((filter) => !filter.valid)) {
     warnings.add(
-      "Some URL filters use regex Chrome doesn't support and were imported disabled."
+      "Some URL filters use regex Chrome doesn't support and won't apply until fixed."
     );
   }
 

--- a/src/utils/io/modHeaderImport.ts
+++ b/src/utils/io/modHeaderImport.ts
@@ -95,7 +95,7 @@ const convertFilters = (
       enabled: filter.enabled !== false,
       type,
       mode: "regex" as const,
-      value: filter.urlRegex as string,
+      value: (filter.urlRegex as string).trim(),
     }));
 };
 

--- a/src/utils/io/modHeaderImport.ts
+++ b/src/utils/io/modHeaderImport.ts
@@ -1,0 +1,153 @@
+import type { HeaderFilter, HeaderSetting, Page } from "../domain/schemas";
+import { filterIsValid } from "../domain/filterValidation";
+
+interface ModHeaderHeaderEntry {
+  enabled?: boolean;
+  name?: string;
+  value?: string;
+  comment?: string;
+  appendMode?: boolean;
+}
+
+interface ModHeaderUrlFilter {
+  enabled?: boolean;
+  urlRegex?: string;
+  methods?: string[];
+}
+
+interface ModHeaderProfile {
+  title?: string;
+  shortTitle?: string;
+  alwaysOn?: boolean;
+  hideComment?: boolean;
+  headers?: ModHeaderHeaderEntry[];
+  respHeaders?: ModHeaderHeaderEntry[];
+  urlFilters?: ModHeaderUrlFilter[];
+  filters?: ModHeaderUrlFilter[];
+  excludeUrlFilters?: ModHeaderUrlFilter[];
+}
+
+/**
+ * ModHeader exports a plain JSON array of profile objects (no wrapper, no
+ * version marker at the array level). Distinguished from a FlexHeader export
+ * by the absence of `showHeaderComments` - a field every FlexHeader page has
+ * carried since before this importer existed - combined with the presence of
+ * a ModHeader-shaped header list.
+ */
+export const isModHeaderExport = (data: unknown): data is ModHeaderProfile[] =>
+  Array.isArray(data) &&
+  data.length > 0 &&
+  data.every((item) => {
+    if (typeof item !== "object" || item === null) return false;
+    const p = item as Record<string, unknown>;
+    if ("showHeaderComments" in p) return false;
+    return Array.isArray(p.headers) || Array.isArray(p.respHeaders);
+  });
+
+const convertHeaders = (
+  headers: ModHeaderHeaderEntry[] | undefined,
+  headerType: HeaderSetting["headerType"],
+  idPrefix: string,
+  warnings: Set<string>
+): HeaderSetting[] =>
+  (headers ?? [])
+    .filter((header) => typeof header?.name === "string" && header.name.trim() !== "")
+    .map((header, index) => {
+      if (header.appendMode) {
+        warnings.add(
+          "ModHeader's append mode isn't supported - those headers were imported as overwrite (Set)."
+        );
+      }
+      return {
+        id: `${idPrefix}-${headerType}-${index + 1}`,
+        headerName: header.name as string,
+        headerValue: header.value ?? "",
+        headerComment: header.comment ?? "",
+        headerEnabled: header.enabled !== false,
+        headerType,
+      };
+    });
+
+const convertFilters = (
+  filters: ModHeaderUrlFilter[] | undefined,
+  type: HeaderFilter["type"],
+  idPrefix: string,
+  warnings: Set<string>
+): Omit<HeaderFilter, "valid">[] => {
+  if (filters?.some((filter) => Array.isArray(filter?.methods) && filter.methods.length > 0)) {
+    warnings.add(
+      "HTTP method filters aren't supported - the imported rules apply to all methods."
+    );
+  }
+
+  return (filters ?? [])
+    .filter((filter) => typeof filter?.urlRegex === "string" && filter.urlRegex.trim() !== "")
+    .map((filter, index) => ({
+      id: `${idPrefix}-${type}-${index + 1}`,
+      enabled: filter.enabled !== false,
+      type,
+      mode: "regex" as const,
+      value: filter.urlRegex as string,
+    }));
+};
+
+/**
+ * Converts one ModHeader profile into a FlexHeader page. `id`/`pageId` are
+ * left for the caller to assign - importSettingsFile mints a fresh pageId
+ * for every imported page regardless of source.
+ *
+ * Imported disabled (`enabled: false`) because the conversion is lossy
+ * (append mode, method filters, and any profile-selection state ModHeader
+ * doesn't include in the export are all dropped) - nothing should start
+ * modifying headers until the user has reviewed it. `alwaysOn` maps to
+ * `keepEnabled` since both mean "stay active regardless of which page/profile
+ * is selected".
+ */
+export const convertModHeaderProfile = async (
+  profile: ModHeaderProfile,
+  index: number,
+  warnings: Set<string>
+): Promise<Page> => {
+  const idPrefix = `mh${index}`;
+  const name =
+    profile.title?.trim() || profile.shortTitle?.trim() || `Imported profile ${index + 1}`;
+
+  const headers = [
+    ...convertHeaders(profile.headers, "request", idPrefix, warnings),
+    ...convertHeaders(profile.respHeaders, "response", idPrefix, warnings),
+  ];
+
+  const rawFilters = [
+    ...convertFilters(profile.urlFilters ?? profile.filters, "include", idPrefix, warnings),
+    ...convertFilters(profile.excludeUrlFilters, "exclude", idPrefix, warnings),
+  ];
+
+  // buildRulesFromPages only applies a filter when filter.valid is true, so
+  // regexes ModHeader accepted but Chrome's RE2 engine rejects need to be
+  // caught here - otherwise they'd silently import as a page whose headers
+  // never fire for that filter.
+  const filters: HeaderFilter[] = await Promise.all(
+    rawFilters.map(
+      (filter) =>
+        new Promise<HeaderFilter>((resolve) => {
+          filterIsValid(filter, (valid) => resolve({ ...filter, valid }));
+        })
+    )
+  );
+
+  if (filters.some((filter) => !filter.valid)) {
+    warnings.add(
+      "Some URL filters use regex Chrome doesn't support and were imported disabled."
+    );
+  }
+
+  return {
+    id: 0,
+    name,
+    enabled: false,
+    keepEnabled: profile.alwaysOn === true,
+    showHeaderComments: !profile.hideComment,
+    headers,
+    filters,
+  };
+};

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -499,7 +499,7 @@ function useFlexHeaderSettings() {
     }
   };
 
-  const importSettings = (file: File): Promise<void> =>
+  const importSettings = (file: File): Promise<{ warnings: string[] }> =>
     importSettingsFile(file, { setPagesData, alertContext });
 
   useEffect(() => {

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -39,7 +39,6 @@ export const defaultPage: Page = {
   enabled: true,
   keepEnabled: false,
   showHeaderComments: true,
-  filtersExpanded: true,
   filters: [],
   lastModified: 0,
   headers: [


### PR DESCRIPTION
## Summary
- Adds support for importing [ModHeader](https://modheader.com) JSON exports (closes #55) — converts profiles into FlexHeader pages via `src/utils/io/modHeaderImport.ts`, with an e2e-verified fixture built from the real export sample in the issue
- Imported pages default to `enabled: false` pending review, since the conversion is lossy (no append-mode headers, no HTTP-method filters, no field-level exclude precedence); a warning is surfaced for any dropped features
- `alwaysOn` maps to `keepEnabled` (both mean "stay active regardless of page selection")
- The drag-and-drop import UI now hints that ModHeader exports are accepted, in addition to FlexHeader's own format
- Fixes an invalid `ignoreDeprecations: "6.0"` value in `e2e/tsconfig.json` that was aborting type-checking for the whole e2e project — this was masking two real, unrelated type errors (missing `filtersExpanded` in a test page builder, and a null-unsafe return type in `pageSection.ts`), both now fixed
- Removes `filtersExpanded`, a `Page` field with no remaining UI or logic reading it

## Test plan
- [x] `bun run typecheck` (root) — clean
- [x] `./node_modules/.bin/tsc --noEmit -p e2e/tsconfig.json` — clean
- [x] `bun run test` — 382 unit tests passing
- [x] `bunx playwright test export-import.spec.ts` — new ModHeader import test passes, along with the rest of the suite (excluding a pre-existing, unrelated "round-trips" flake reproducible on unmodified `main`)