### PR TITLE
Add sort headers by enabled/disabled

### DIFF
--- a/e2e/header-sort.spec.ts
+++ b/e2e/header-sort.spec.ts
@@ -58,6 +58,40 @@ test.describe("Header Sort", () => {
     await expect(popupPage.headers.getHeaderComment(2)).resolves.toBe("third");
   });
 
+  test("sorts headers by enabled ascending (disabled first)", async ({ popupPage }) => {
+    await popupPage.pages.addEmptyPage();
+    await popupPage.headers.addHeader("Alpha", "a-value");
+    await popupPage.headers.addHeader("Bravo", "b-value");
+    await popupPage.headers.addHeader("Charlie", "c-value");
+
+    // All headers start enabled by default; disable the first two.
+    await popupPage.headers.toggleHeader(0);
+    await popupPage.headers.toggleHeader(1);
+
+    await popupPage.headers.sortBy("headerEnabled", "asc");
+
+    await expect(popupPage.headers.isHeaderEnabled(0)).resolves.toBe(false);
+    await expect(popupPage.headers.isHeaderEnabled(1)).resolves.toBe(false);
+    await expect(popupPage.headers.isHeaderEnabled(2)).resolves.toBe(true);
+    await expect(popupPage.headers.getHeaderName(2)).resolves.toBe("Charlie");
+  });
+
+  test("sorts headers by enabled descending (enabled first)", async ({ popupPage }) => {
+    await popupPage.pages.addEmptyPage();
+    await popupPage.headers.addHeader("Alpha", "a-value");
+    await popupPage.headers.addHeader("Bravo", "b-value");
+    await popupPage.headers.addHeader("Charlie", "c-value");
+
+    await popupPage.headers.toggleHeader(1);
+
+    await popupPage.headers.sortBy("headerEnabled", "desc");
+
+    await expect(popupPage.headers.isHeaderEnabled(0)).resolves.toBe(true);
+    await expect(popupPage.headers.isHeaderEnabled(1)).resolves.toBe(true);
+    await expect(popupPage.headers.isHeaderEnabled(2)).resolves.toBe(false);
+    await expect(popupPage.headers.getHeaderName(2)).resolves.toBe("Bravo");
+  });
+
   test("sort is a one-time operation, not persisted as a setting", async ({ popupPage }) => {
     await popupPage.pages.addEmptyPage();
     await popupPage.headers.addHeader("Zebra", "z-value");

--- a/e2e/pages/headerSection.ts
+++ b/e2e/pages/headerSection.ts
@@ -95,7 +95,7 @@ export class HeaderSection {
    * The popup closes itself on apply.
    */
   async sortBy(
-    field: "headerName" | "headerValue" | "headerComment",
+    field: "headerName" | "headerValue" | "headerComment" | "headerEnabled",
     direction: "asc" | "desc" = "asc"
   ): Promise<void> {
     await this.sortButton.click();

--- a/src/components/sortHeadersDropdown/index.tsx
+++ b/src/components/sortHeadersDropdown/index.tsx
@@ -4,13 +4,18 @@ import Button from "../button";
 import Sort from "../icons/Sort";
 import "./index.css";
 
-type SortField = "headerName" | "headerValue" | "headerComment";
+type SortField =
+  | "headerName"
+  | "headerValue"
+  | "headerComment"
+  | "headerEnabled";
 type SortDirection = "asc" | "desc";
 
 const FIELD_OPTIONS: { value: SortField; label: string }[] = [
   { value: "headerName", label: "Header Name" },
   { value: "headerValue", label: "Header Value" },
   { value: "headerComment", label: "Comment" },
+  { value: "headerEnabled", label: "Enabled" },
 ];
 
 const SortHeadersDropdown = ({
@@ -54,9 +59,12 @@ const SortHeadersDropdown = ({
 
   const _handleSort = () => {
     const sorted = [...headers].sort((a, b) => {
-      const result = a[field].localeCompare(b[field], undefined, {
-        sensitivity: "base",
-      });
+      const result =
+        field === "headerEnabled"
+          ? Number(a.headerEnabled) - Number(b.headerEnabled)
+          : a[field].localeCompare(b[field], undefined, {
+              sensitivity: "base",
+            });
       return direction === "asc" ? result : -result;
     });
     onSort(sorted);


### PR DESCRIPTION
## Summary
- Adds an "Enabled" option to the header sort dropdown, alongside Header Name/Value/Comment
- Sorts by the `headerEnabled` boolean (ascending puts disabled headers first, descending puts enabled first)

## Test plan
- [x] Added two e2e tests in `e2e/header-sort.spec.ts` covering ascending and descending enabled-sort
- [x] `bun run test:e2e -- header-sort.spec.ts` — all 7 tests pass
- [x] Manually verified in the web-dev preview: toggling headers then sorting by Enabled groups disabled headers correctly

Note: found a pre-existing, unrelated bug where the sort dropdown panel can render off-screen to the left due to a position calc issue in `sortHeadersDropdown/index.tsx`. Not touched here — out of scope for this change.