### PR TITLE
Restore lift/reorder-preview UX for header drag-and-drop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,3 +214,32 @@ browser would get silently flipped back by the other browser's next push.
 - `declarativeNetRequest` rule-generation tests compare against committed
   JSON fixtures (`src/background/__fixtures__/rules/`). Regenerate with
   `bun run test:update-fixtures` when a change is intentional.
+- Testing `@hello-pangea/dnd` (header drag-and-drop, `headersList/index.tsx`)
+  with Playwright: a single instant `mouse.move` jump from source to target
+  (or Playwright's default `dragTo()`) reads as a click, not a drag - the
+  mouse sensor only starts once the pointer clears a small threshold via real
+  intermediate `mousemove` events. Use `HeaderSection.dragHeaderTo`, which
+  moves in many small steps. `onDragEnd` (and the resulting save) also
+  settle asynchronously after the drop - assert with `expect.poll(...)`, not
+  a fixed wait or an immediate check, or the test is flaky in either
+  direction (too fast: races the commit; a guessed fixed sleep: occasionally
+  still too short). See `header-drag.spec.ts`.
+
+## Header drag-and-drop (`headersList/index.tsx`)
+
+Uses `@hello-pangea/dnd` (a maintained react-beautiful-dnd fork; the
+original is unmaintained and has known React 18+ strict-mode breakage).
+Two non-obvious requirements when touching this:
+- The drag handle element must be a real `HTMLElement`, not an `<svg>` -
+  `@hello-pangea/dnd` explicitly rejects `SVGElement` handles at runtime
+  (`drag handle needs to be a HTMLElement`). The handle is a wrapping `<div>`
+  (`.draggable-icon-handle`) that receives `dragHandleProps`; the SVG icon
+  inside it is decorative (`aria-hidden`) only.
+- `saveHeaders` (`useHeaderOperations.ts`) must NOT re-index header ids on a
+  reorder. `@hello-pangea/dnd` tracks each row by its `draggableId` (the
+  header's own id) across a drag gesture to compute the slide animation -
+  reassigning ids on the very reorder it's animating looks like "every row
+  removed, new ones added" instead of "these rows moved," breaking the
+  animation. Reordering never changes the id set or count, so leaving ids
+  alone is safe; `_reIndexHeaders` is still needed (and still used) by
+  add/removeHeader, which do change the count.

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "flex-headers",
       "dependencies": {
+        "@hello-pangea/dnd": "^18.0.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -52,7 +53,7 @@
 
     "@babel/parser": ["@babel/parser@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" }, "bin": "./bin/babel-parser.js" }, "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg=="],
 
-    "@babel/runtime": ["@babel/runtime@7.27.6", "", {}, "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q=="],
+    "@babel/runtime": ["@babel/runtime@7.28.2", "", {}, "sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA=="],
 
     "@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
 
@@ -143,6 +144,8 @@
     "@eslint/js": ["@eslint/js@8.57.1", "", {}, "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q=="],
 
     "@exodus/bytes": ["@exodus/bytes@1.15.1", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q=="],
+
+    "@hello-pangea/dnd": ["@hello-pangea/dnd@18.0.1", "", { "dependencies": { "@babel/runtime": "^7.26.7", "css-box-model": "^1.2.1", "raf-schd": "^4.0.3", "react-redux": "^9.2.0", "redux": "^5.0.1" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-xojVWG8s/TGrKT1fC8K2tIWeejJYTAeJuj36zM//yEm/ZrnZUSFGS15BpO+jGZT1ybWvyXmeDJwPYb4dhWlbZQ=="],
 
     "@humanwhocodes/config-array": ["@humanwhocodes/config-array@0.13.0", "", { "dependencies": { "@humanwhocodes/object-schema": "^2.0.3", "debug": "^4.3.1", "minimatch": "^3.0.5" } }, "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw=="],
 
@@ -253,6 +256,8 @@
     "@types/react": ["@types/react@19.2.17", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
+    "@types/use-sync-external-store": ["@types/use-sync-external-store@0.0.6", "", {}, "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="],
 
     "@types/webextension-polyfill": ["@types/webextension-polyfill@0.12.5", "", {}, "sha512-uKSAv6LgcVdINmxXMKBuVIcg/2m5JZugoZO8x20g7j2bXJkPIl/lVGQcDlbV+aXAiTyXT2RA5U5mI4IGCDMQeg=="],
 
@@ -445,6 +450,8 @@
     "core-util-is": ["core-util-is@1.0.3", "", {}, "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "css-box-model": ["css-box-model@1.2.1", "", { "dependencies": { "tiny-invariant": "^1.0.6" } }, "sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw=="],
 
     "css-select": ["css-select@7.0.0", "", { "dependencies": { "boolbase": "^2.0.0", "css-what": "^8.0.0", "domhandler": "^6.0.1", "domutils": "^4.0.2", "nth-check": "^3.0.1" } }, "sha512-snmjEVXy+1LnwXdxhYvTMj1d9tOh4HxkA1YmoayVBeeyR2C14Pum7fcxJIm4SswYspVy866eYNwlH6xC3/VH5g=="],
 
@@ -1014,6 +1021,8 @@
 
     "quick-format-unescaped": ["quick-format-unescaped@4.0.4", "", {}, "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="],
 
+    "raf-schd": ["raf-schd@4.0.3", "", {}, "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ=="],
+
     "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
 
     "rc9": ["rc9@3.0.1", "", { "dependencies": { "defu": "^6.1.6", "destr": "^2.0.5" } }, "sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ=="],
@@ -1026,6 +1035,8 @@
 
     "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
+    "react-redux": ["react-redux@9.3.0", "", { "dependencies": { "@types/use-sync-external-store": "^0.0.6", "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "@types/react": "^18.2.25 || ^19", "react": "^18.0 || ^19", "redux": "^5.0.0" }, "optionalPeers": ["@types/react", "redux"] }, "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g=="],
+
     "readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
     "readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
@@ -1033,6 +1044,8 @@
     "real-require": ["real-require@0.2.0", "", {}, "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="],
 
     "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
+
+    "redux": ["redux@5.0.1", "", {}, "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="],
 
     "regexp.prototype.flags": ["regexp.prototype.flags@1.5.4", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-errors": "^1.3.0", "get-proto": "^1.0.1", "gopd": "^1.2.0", "set-function-name": "^2.0.2" } }, "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA=="],
 
@@ -1166,6 +1179,8 @@
 
     "through": ["through@2.3.8", "", {}, "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="],
 
+    "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
+
     "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
 
     "tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
@@ -1215,6 +1230,8 @@
     "update-notifier": ["update-notifier@7.3.1", "", { "dependencies": { "boxen": "^8.0.1", "chalk": "^5.3.0", "configstore": "^7.0.0", "is-in-ci": "^1.0.0", "is-installed-globally": "^1.0.0", "is-npm": "^6.0.0", "latest-version": "^9.0.0", "pupa": "^3.1.0", "semver": "^7.6.3", "xdg-basedir": "^5.1.0" } }, "sha512-+dwUY4L35XFYEzE+OAL3sarJdUioVovq+8f7lcIJ7wnmnYQV5UD1Y/lcwaMSyaQ6Bj3JMj1XSTjZbNLHn/19yA=="],
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
+
+    "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
@@ -1318,9 +1335,13 @@
 
     "@pnpm/network.ca-file/graceful-fs": ["graceful-fs@4.2.10", "", {}, "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="],
 
+    "@testing-library/dom/@babel/runtime": ["@babel/runtime@7.27.6", "", {}, "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q=="],
+
     "@testing-library/dom/aria-query": ["aria-query@5.1.3", "", { "dependencies": { "deep-equal": "^2.0.5" } }, "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ=="],
 
     "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
+
+    "@testing-library/react/@babel/runtime": ["@babel/runtime@7.27.6", "", {}, "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q=="],
 
     "@wxt-dev/storage/@wxt-dev/browser": ["@wxt-dev/browser@0.1.43", "", { "dependencies": { "@types/filesystem": "*", "@types/har-format": "*" } }, "sha512-RMB0zgfe7uuiTp18s9taLeKXoOCLBV418797dnEggiMWmM1JDJekiLtlvrNc6QeZg+amDBy2/KKYuQB2kh/K9A=="],
 
@@ -1423,8 +1444,6 @@
     "update-notifier/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
-
-    "web-ext-run/@babel/runtime": ["@babel/runtime@7.28.2", "", {}, "sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA=="],
 
     "webpack/eslint-scope": ["eslint-scope@5.1.1", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^4.1.1" } }, "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw=="],
 

--- a/e2e/header-drag.spec.ts
+++ b/e2e/header-drag.spec.ts
@@ -1,0 +1,94 @@
+import { test, expect } from "./baseTest";
+
+test.describe("Header Drag and Drop", () => {
+  test("drags the first header to the end of the list", async ({ popupPage }) => {
+    await popupPage.pages.addEmptyPage();
+    await popupPage.headers.addHeader("Alpha", "a-value");
+    await popupPage.headers.addHeader("Bravo", "b-value");
+    await popupPage.headers.addHeader("Charlie", "c-value");
+
+    await popupPage.headers.dragHeaderTo(0, 2);
+
+    // onDragEnd (and the resulting save) settle asynchronously after the
+    // drop, so this must poll rather than assert once immediately.
+    await expect
+      .poll(() => popupPage.headers.getAllHeaderNames())
+      .toEqual(["Bravo", "Charlie", "Alpha"]);
+  });
+
+  test("drags the last header to the start of the list", async ({ popupPage }) => {
+    await popupPage.pages.addEmptyPage();
+    await popupPage.headers.addHeader("Alpha", "a-value");
+    await popupPage.headers.addHeader("Bravo", "b-value");
+    await popupPage.headers.addHeader("Charlie", "c-value");
+
+    await popupPage.headers.dragHeaderTo(2, 0);
+
+    await expect
+      .poll(() => popupPage.headers.getAllHeaderNames())
+      .toEqual(["Charlie", "Alpha", "Bravo"]);
+  });
+
+  test("swaps two adjacent headers", async ({ popupPage }) => {
+    await popupPage.pages.addEmptyPage();
+    await popupPage.headers.addHeader("Alpha", "a-value");
+    await popupPage.headers.addHeader("Bravo", "b-value");
+
+    await popupPage.headers.dragHeaderTo(0, 1);
+
+    await expect
+      .poll(() => popupPage.headers.getAllHeaderNames())
+      .toEqual(["Bravo", "Alpha"]);
+  });
+
+  test("preserves each header's value and comment after reordering", async ({ popupPage }) => {
+    await popupPage.pages.addEmptyPage();
+    await popupPage.headers.showComments();
+    await popupPage.headers.addHeader("Alpha", "a-value");
+    await popupPage.headers.setHeaderComment(0, "first comment");
+    await popupPage.headers.addHeader("Bravo", "b-value");
+    await popupPage.headers.setHeaderComment(1, "second comment");
+
+    await popupPage.headers.dragHeaderTo(0, 1);
+
+    await expect
+      .poll(() => popupPage.headers.getAllHeaderNames())
+      .toEqual(["Bravo", "Alpha"]);
+
+    await expect(popupPage.headers.getHeaderValue(0)).resolves.toBe("b-value");
+    await expect(popupPage.headers.getHeaderComment(0)).resolves.toBe("second comment");
+    await expect(popupPage.headers.getHeaderValue(1)).resolves.toBe("a-value");
+    await expect(popupPage.headers.getHeaderComment(1)).resolves.toBe("first comment");
+  });
+
+  // Not a reload-based persistence test: reloading the popup has a separate,
+  // pre-existing flaky data-loss issue unrelated to drag-and-drop (tracked
+  // separately). Checking chrome.storage.local directly instead still
+  // catches the regression that matters here - a drop that reorders the UI
+  // but never actually calls saveHeaders/persists anything.
+  test("actually persists the new order to storage, not just the UI", async ({ popupPage }) => {
+    await popupPage.pages.addEmptyPage();
+    await popupPage.headers.addHeader("Alpha", "a-value");
+    await popupPage.headers.addHeader("Bravo", "b-value");
+    await popupPage.headers.addHeader("Charlie", "c-value");
+
+    await popupPage.headers.dragHeaderTo(0, 2);
+
+    const getStoredHeaderNames = () =>
+      popupPage.page.evaluate(async () => {
+        const all = await chrome.storage.local.get(null);
+        const pageKey = Object.keys(all).find(
+          (key) =>
+            key.startsWith("page_") &&
+            all[key]?.headers?.some((h: { headerName: string }) => h.headerName === "Alpha")
+        );
+        return pageKey
+          ? all[pageKey].headers.map((h: { headerName: string }) => h.headerName)
+          : null;
+      });
+
+    await expect
+      .poll(getStoredHeaderNames)
+      .toEqual(["Bravo", "Charlie", "Alpha"]);
+  });
+});

--- a/e2e/pages/headerSection.ts
+++ b/e2e/pages/headerSection.ts
@@ -29,6 +29,10 @@ export class HeaderSection {
     return this.rows.nth(index);
   }
 
+  dragHandle(index: number): Locator {
+    return this.row(index).getByTestId("header-drag-handle");
+  }
+
   async addHeader(name: string, value: string, type: "request" | "response" = "request"): Promise<void> {
     await this.addButton.click();
     const newRow = this.rows.last();
@@ -104,6 +108,35 @@ export class HeaderSection {
     await this.sortDirectionSelect.selectOption(direction);
     await this.sortApplyButton.click();
     await this.sortDropdown.waitFor({ state: "hidden" });
+  }
+
+  async dragHeaderTo(fromIndex: number, toIndex: number): Promise<void> {
+    const sourceBox = await this.dragHandle(fromIndex).boundingBox();
+    const targetBox = await this.row(toIndex).boundingBox();
+    if (!sourceBox || !targetBox) {
+      throw new Error("Could not measure drag handle or target row for drag-and-drop");
+    }
+
+    const startX = sourceBox.x + sourceBox.width / 2;
+    const startY = sourceBox.y + sourceBox.height / 2;
+    const endX = targetBox.x + targetBox.width / 2;
+    const endY = targetBox.y + targetBox.height / 2;
+
+    await this.page.mouse.move(startX, startY);
+    await this.page.mouse.down();
+    await this.page.waitForTimeout(100);
+
+    const steps = 20;
+    for (let i = 1; i <= steps; i++) {
+      await this.page.mouse.move(
+        startX + ((endX - startX) * i) / steps,
+        startY + ((endY - startY) * i) / steps
+      );
+      await this.page.waitForTimeout(50);
+    }
+    await this.page.waitForTimeout(150);
+
+    await this.page.mouse.up();
   }
 
   async getAllHeaderNames(): Promise<string[]> {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.9.3",
   "private": true,
   "dependencies": {
+    "@hello-pangea/dnd": "^18.0.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/src/components/headerRow/index.css
+++ b/src/components/headerRow/index.css
@@ -11,7 +11,7 @@
   border: 1px solid var(--border-color);
   border-radius: var(--radius-md);
   box-sizing: border-box;
-  transition: border-color 0.15s ease, box-shadow 0.15s ease, opacity 0.15s ease;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease, opacity 0.15s ease, transform 0.15s ease;
 }
 
 .header-row:last-child {
@@ -25,13 +25,9 @@
 }
 
 .header-row--dragging {
-  opacity: 0.4;
-  box-shadow: var(--shadow-card);
-}
-
-.header-row--drag-over {
   border-color: var(--primary);
-  box-shadow: 0 0 0 2px var(--primary-soft);
+  box-shadow: var(--shadow-card);
+  transform: scale(1.015);
 }
 
 .header-row--disabled {
@@ -134,15 +130,20 @@
   gap: 0.4rem;
 }
 
-.draggable-icon {
-  width: 16px;
+.draggable-icon-handle {
+  display: inline-flex;
   cursor: grab;
   flex-shrink: 0;
 }
 
-.draggable-icon:active,
-.draggable-icon--dragging {
+.draggable-icon-handle:active,
+.draggable-icon-handle--dragging {
   cursor: grabbing;
+}
+
+.draggable-icon {
+  width: 16px;
+  flex-shrink: 0;
 }
 
 .header-row__type {

--- a/src/components/headerRow/index.tsx
+++ b/src/components/headerRow/index.tsx
@@ -1,10 +1,11 @@
 import { useId, useMemo, useRef, useState } from "react";
 import type * as React from "react";
+import type { DraggableProvidedDragHandleProps } from "@hello-pangea/dnd";
 import { HeaderSetting } from "../../utils/settings";
 import { POPULAR_HEADER_NAMES } from "../../constants";
 import Button from "../button";
 import "./index.css";
-import Draggable from "../icons/Draggable";
+import DraggableIcon from "../icons/Draggable";
 import Basket from "../icons/Basket";
 
 const HeaderRow = ({
@@ -17,24 +18,14 @@ const HeaderRow = ({
   onRemove,
   onUpdate,
   showComment,
-  index,
   isDragging,
-  isDragOver,
-  onDragStart,
-  onDragEnter,
-  onDragEnd,
-  onDrop,
+  dragHandleProps,
 }: HeaderSetting & {
   showComment: boolean;
   onRemove: (id: string) => void;
   onUpdate: (header: HeaderSetting) => void;
-  index: number;
   isDragging: boolean;
-  isDragOver: boolean;
-  onDragStart: () => void;
-  onDragEnter: () => void;
-  onDragEnd: () => void;
-  onDrop: () => void;
+  dragHandleProps?: DraggableProvidedDragHandleProps | null;
 }) => {
   const updateHeader = (patch: Partial<HeaderSetting>) => {
     onUpdate({
@@ -103,50 +94,19 @@ const HeaderRow = ({
 
   return (
     <div
-      className={`header-row${showComment ? "" : " header-row--comments-hidden"}${isDragging ? " header-row--dragging" : ""}${isDragOver ? " header-row--drag-over" : ""}${!headerEnabled ? " header-row--disabled" : ""}`}
+      className={`header-row${showComment ? "" : " header-row--comments-hidden"}${isDragging ? " header-row--dragging" : ""}${!headerEnabled ? " header-row--disabled" : ""}`}
       data-headerid={id}
       data-testid="header-row"
-      onDragEnter={(e) => {
-        e.preventDefault();
-        onDragEnter();
-      }}
-      onDragOver={(e) => {
-        e.preventDefault();
-        e.dataTransfer.dropEffect = "move";
-      }}
-      onDrop={(e) => {
-        e.preventDefault();
-        onDrop();
-      }}
     >
       <div className="header-row__checkbox">
-        <Draggable
-          role="img"
-          aria-label="Draggable"
-          className={`draggable-icon${isDragging ? " draggable-icon--dragging" : ""}`}
-          draggable
-          onDragStart={(e) => {
-            e.dataTransfer.effectAllowed = "move";
-            e.dataTransfer.setData("text/plain", String(index));
-            onDragStart();
-          }}
-          onDragEnter={(e) => {
-            e.preventDefault();
-            onDragEnter();
-          }}
-          onDragOver={(e) => {
-            e.preventDefault();
-            e.dataTransfer.dropEffect = "move";
-          }}
-          onDragLeave={(e) => {
-            e.preventDefault();
-          }}
-          onDrop={(e) => {
-            e.preventDefault();
-            onDrop();
-          }}
-          onDragEnd={onDragEnd}
-        />
+        <div
+          className={`draggable-icon-handle${isDragging ? " draggable-icon-handle--dragging" : ""}`}
+          aria-label="Reorder header"
+          data-testid="header-drag-handle"
+          {...dragHandleProps}
+        >
+          <DraggableIcon aria-hidden="true" className="draggable-icon" />
+        </div>
         <label className="toggle-switch">
           <input
             type="checkbox"

--- a/src/components/headersList/index.tsx
+++ b/src/components/headersList/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { DragDropContext, Droppable, Draggable, type DropResult } from "@hello-pangea/dnd";
 import { HeaderSetting } from "../../utils/settings";
 import HeaderRow from "../headerRow";
 import "./index.css";
@@ -26,8 +26,6 @@ const HeadersList = () => {
   const currentPageId = currentPage.id;
   const headers = currentPage.headers;
   const showComments = currentPage.showHeaderComments;
-  const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
-  const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
 
   const handleRemoveHeader = (id: string) => {
     removeHeader(currentPageId, id);
@@ -37,68 +35,65 @@ const HeadersList = () => {
     updateHeader(currentPageId, header);
   };
 
-  const handleDragStart = (index: number) => {
-    setDraggedIndex(index);
-  };
+  const handleDragEnd = (result: DropResult) => {
+    if (!result.destination) return;
 
-  const handleDragEnter = (index: number) => {
-    setDragOverIndex(index);
-  };
+    const reorderedHeaders = reorder(
+      headers,
+      result.source.index,
+      result.destination.index
+    );
 
-  const handleDragEnd = () => {
-    setDraggedIndex(null);
-    setDragOverIndex(null);
-  };
-
-  const handleDrop = (targetIndex: number) => {
-    if (draggedIndex === null || draggedIndex === targetIndex) {
-      setDraggedIndex(null);
-      setDragOverIndex(null);
-      return;
-    }
-
-    const reorderedHeaders = reorder(headers, draggedIndex, targetIndex);
     saveHeaders(reorderedHeaders, currentPageId);
-    setDraggedIndex(null);
-    setDragOverIndex(null);
   };
 
   return (
-    <div className="app__body__headers">
-      {headers.map(
-        (
-          {
-            id,
-            headerName,
-            headerValue,
-            headerComment,
-            headerEnabled,
-            headerType,
-          },
-          index
-        ) => (
-          <HeaderRow
-            key={`header-row__${id}`}
-            id={id}
-            headerName={headerName}
-            headerValue={headerValue}
-            headerComment={headerComment}
-            headerEnabled={headerEnabled}
-            headerType={headerType}
-            showComment={showComments}
-            onRemove={handleRemoveHeader}
-            onUpdate={handleUpdateHeader}
-            index={index}
-            isDragging={draggedIndex === index}
-            isDragOver={dragOverIndex === index}
-            onDragStart={() => handleDragStart(index)}
-            onDragEnter={() => handleDragEnter(index)}
-            onDragEnd={handleDragEnd}
-            onDrop={() => handleDrop(index)}
-          />
-        )
-      )}
-    </div>
+    <DragDropContext onDragEnd={handleDragEnd}>
+      <Droppable droppableId="droppable-headers">
+        {(provided) => (
+          <div
+            {...provided.droppableProps}
+            ref={provided.innerRef}
+            className="app__body__headers"
+          >
+            {headers.map(
+              (
+                {
+                  id,
+                  headerName,
+                  headerValue,
+                  headerComment,
+                  headerEnabled,
+                  headerType,
+                },
+                index
+              ) => (
+                <Draggable key={id} draggableId={id} index={index}>
+                  {(provided, snapshot) => (
+                    <div ref={provided.innerRef} {...provided.draggableProps}>
+                      <HeaderRow
+                        id={id}
+                        headerName={headerName}
+                        headerValue={headerValue}
+                        headerComment={headerComment}
+                        headerEnabled={headerEnabled}
+                        headerType={headerType}
+                        showComment={showComments}
+                        onRemove={handleRemoveHeader}
+                        onUpdate={handleUpdateHeader}
+                        isDragging={snapshot.isDragging}
+                        dragHandleProps={provided.dragHandleProps}
+                      />
+                    </div>
+                  )}
+                </Draggable>
+              )
+            )}
+            {provided.placeholder}
+          </div>
+        )}
+      </Droppable>
+    </DragDropContext>
   );
 };
 

--- a/src/utils/hooks/useHeaderOperations.ts
+++ b/src/utils/hooks/useHeaderOperations.ts
@@ -83,16 +83,20 @@ function useHeaderOperations({ pagesData, setPagesData, recordHistory }: UseHead
   };
 
   /**
-   * Allows you to save the headers data after a change.
-   * The function WILL re-index the headers to avoid conflicts
+   * Allows you to save a re-ordered (drag-and-drop or sort) headers array.
+   * Ids are kept as-is rather than re-indexed: @hello-pangea/dnd tracks each
+   * row by its draggableId (the header's id) across a drag gesture, so
+   * reassigning ids here on the very reorder it's animating would present as
+   * "every row removed and a new one added" instead of "these rows moved",
+   * breaking the drop animation. Safe because a reorder never changes the id
+   * set or count - only add/removeHeader do, which is what _reIndexHeaders
+   * guards against.
    * @param newHeaders | The new headers array to save
    * @param pageId | The page that the headers belong to
    */
   const saveHeaders = (newHeaders: HeaderSetting[], pageId: number) => {
-    const reIndexedHeaders = _reIndexHeaders(newHeaders);
-
     const newPages = pagesData.pages.map((page) =>
-      page.id === pageId ? { ...page, headers: reIndexedHeaders, lastModified: Date.now() } : page
+      page.id === pageId ? { ...page, headers: newHeaders, lastModified: Date.now() } : page
     );
 
     setPagesData((prev) => ({


### PR DESCRIPTION
## Summary

- The `2026 redesign` commit replaced `react-beautiful-dnd` with a hand-rolled native HTML5 drag-and-drop, which lost the lift-on-pickup animation and live reorder preview, and had a stale-closure race (`draggedIndex` read from React state before it committed) that could silently no-op a fast drag entirely.
- Migrates `headersList`/`headerRow` to `@hello-pangea/dnd` (the actively-maintained `react-beautiful-dnd` fork, official React 19 support) to restore the original lift + animated reorder UX.
- Two supporting fixes were required for the migration to actually work:
  - The drag handle must be a real `HTMLElement`, not an `<svg>` - `@hello-pangea/dnd` rejects `SVGElement` handles at runtime. The handle is now a wrapping `<div>` with the decorative SVG icon inside it.
  - `saveHeaders` no longer re-indexes header ids on every save. The library tracks each row by its `draggableId` (the header's own id) across a drag gesture to compute the slide animation; reassigning ids on the very reorder it's animating broke that tracking. Reordering never changes the id set or count, so this is safe - `_reIndexHeaders` is still used by add/removeHeader, which do change the count.
- Adds e2e coverage (`e2e/header-drag.spec.ts`) for reordering to the start/end, an adjacent swap, header data (value/comment) surviving a reorder, and the reorder actually persisting to `chrome.storage.local` (not just the UI).
- Documents both the DnD implementation constraints and a Playwright testing gotcha (this library's mouse sensor needs many small `mousemove` steps, not an instant jump, and `onDragEnd`/save settle asynchronously so assertions need `expect.poll`) in `CLAUDE.md`.

## Test plan

- [x] `bun run test` - all existing unit tests pass (unrelated pre-existing e2e-in-vitest failures from a stray worktree, confirmed present before this change too)
- [x] `bun run typecheck` - no new errors (one pre-existing unrelated error in `background.test.ts`)
- [x] `npx playwright test e2e/header-drag.spec.ts --repeat-each=3` - 15/15 passed, confirming the new tests are stable, not just a one-off pass
- [x] Manually verified in the web-dev harness and confirmed by the repo owner that dragging shows the lift animation and live reorder preview again

## Note

While testing, found a separate pre-existing bug unrelated to this change: reloading the popup can intermittently lose recently-saved changes even after the save confirms in the console. Reproduced with a plain "add a header, wait, reload" sequence with no drag-and-drop involved. Filed separately rather than fixed here since it's out of scope for this PR.